### PR TITLE
fix: wolventech CTA booking link + favicon

### DIFF
--- a/apps/wolventech/.env.example
+++ b/apps/wolventech/.env.example
@@ -1,0 +1,32 @@
+# Wolven Tech — production environment
+# Copy to .env and fill in real values. NEXT_PUBLIC_* are baked at build time.
+
+# --- Required ---
+
+# Resend — booking confirmation emails
+RESEND_API_KEY=
+
+# Google Calendar — availability checks + event creation
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REFRESH_TOKEN=
+
+# Cloudflare Turnstile — bot protection on contact/booking form
+# Secret = server-side verify; Site key = client widget. Both required.
+TURNSTILE_SECRET_KEY=
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=
+
+# --- Optional (defaults shown) ---
+
+# Only needed when minting GOOGLE_REFRESH_TOKEN via OAuth flow
+GOOGLE_REDIRECT_URI=https://wolventech.io/api/auth/google/callback
+
+# From / reply-to addresses
+EMAIL_FROM=discovery@wolventech.io
+EMAIL_REPLY_TO=discovery@wolventech.io
+
+# Calendar owner whose availability is checked
+CALENDAR_OWNER_EMAIL=discovery@wolventech.io
+
+# Public site URL (used in emails + metadata)
+NEXT_PUBLIC_APP_URL=https://wolventech.io

--- a/apps/wolventech/src/app/icon.svg
+++ b/apps/wolventech/src/app/icon.svg
@@ -1,0 +1,17 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ce422b" />
+      <stop offset="1" stop-color="#ffa657" />
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="url(#g)" />
+  <path
+    d="M7 9 L11.5 23 L16 15 L20.5 23 L25 9"
+    fill="none"
+    stroke="#fff"
+    stroke-width="2.4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/apps/wolventech/src/app/page.tsx
+++ b/apps/wolventech/src/app/page.tsx
@@ -3,7 +3,6 @@ import TerminalManifest from '@/components/TerminalManifest'
 import {
   artifacts,
   cases,
-  contactEmail,
   credentials,
   proofPoints,
   services,
@@ -320,7 +319,7 @@ export default function HomePage() {
             size="lg"
             className="bg-rust-primary font-semibold text-white shadow-[0_10px_28px_-14px_rgba(206,66,43,0.7)] hover:bg-rust-primary-2"
           >
-            <a href={`mailto:${contactEmail}?subject=Wolven%20Tech%20discovery`}>{contactEmail}</a>
+            <a href="/contact">Book discovery</a>
           </Button>
         </div>
       </section>

--- a/apps/wolventech/src/lib/content.ts
+++ b/apps/wolventech/src/lib/content.ts
@@ -240,8 +240,6 @@ export const socialLinks: SiteLink[] = [
   { label: '@ddonprogramming', href: 'https://x.com/ddonprogramming' },
 ]
 
-export const contactEmail = 'discovery@decebaldobrica.com'
-
 export type TerminalLine = {
   type: 'comment' | 'section' | 'entry' | 'prompt' | 'blank'
   key?: string


### PR DESCRIPTION
## Summary
- CTA "Ready to talk Rust?" now links to `/contact` (booking form) instead of a hardcoded `discovery@decebaldobrica.com` mailto — wrong brand + dead-ended at email. Matches the Navbar "Book discovery" button.
- Removed the now-unused `contactEmail` export.
- Added `apps/wolventech/.env.example` documenting production env (Resend, Google Calendar, Cloudflare Turnstile).
- Added `app/icon.svg` favicon — gradient rounded-square **W** matching the navbar logo (`#ce422b → #ffa657`). wolventech had no favicon.

## Test plan
- `task dev` (wolventech) → CTA button routes to `/contact`
- Tab favicon renders; `/icon.svg` serves the W mark
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)