### PR TITLE
fix: wolventech contact — remove empty AI section + double footer

### DIFF
--- a/apps/wolventech/src/app/contact/page.tsx
+++ b/apps/wolventech/src/app/contact/page.tsx
@@ -1,5 +1,4 @@
 import { bookMeeting } from '@/actions/meeting-action'
-import Footer from '@/components/Footer'
 import ContactBookingPage from '@decebal/booking/ContactBookingPage'
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
@@ -27,7 +26,6 @@ export default function ContactPage() {
         enablePayments={false}
         theme="rust"
         chatConfig={{ enabled: false }}
-        footer={<Footer />}
       />
     </Suspense>
   )

--- a/apps/wolventech/src/app/layout.tsx
+++ b/apps/wolventech/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, JetBrains_Mono } from 'next/font/google'
 import './globals.css'
 import Footer from '@/components/Footer'
 import Navbar from '@/components/Navbar'
+import { Toaster } from '@decebal/ui/toaster'
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
 const jetbrains = JetBrains_Mono({ subsets: ['latin'], variable: '--font-jetbrains-mono' })
@@ -72,6 +73,7 @@ export default function RootLayout({
         <Navbar />
         {children}
         <Footer />
+        <Toaster />
       </body>
     </html>
   )

--- a/packages/booking/src/ContactBookingPage.tsx
+++ b/packages/booking/src/ContactBookingPage.tsx
@@ -544,36 +544,38 @@ export default function ContactBookingPage({
             </motion.div>
 
             {/* Chat Section on Success Page */}
-            <motion.div
-              className="max-w-4xl mx-auto mt-16"
-              initial={{ opacity: 0, y: 30 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 1.2, duration: 0.6 }}
-              data-success-chat-section
-            >
-              <div className="text-center mb-6">
-                <div className="flex items-center justify-center gap-2 mb-3">
-                  <motion.div
-                    animate={{ rotate: [0, 10, -10, 0] }}
-                    transition={{ duration: 2, repeat: Number.POSITIVE_INFINITY, repeatDelay: 3 }}
-                  >
-                    <MessageSquare className="h-6 w-6 text-brand-teal" />
-                  </motion.div>
-                  <h2 className="text-2xl font-bold text-white">
-                    Want to Learn More About Working Together?
-                  </h2>
+            {chatConfig?.enabled !== false && (
+              <motion.div
+                className="max-w-4xl mx-auto mt-16"
+                initial={{ opacity: 0, y: 30 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 1.2, duration: 0.6 }}
+                data-success-chat-section
+              >
+                <div className="text-center mb-6">
+                  <div className="flex items-center justify-center gap-2 mb-3">
+                    <motion.div
+                      animate={{ rotate: [0, 10, -10, 0] }}
+                      transition={{ duration: 2, repeat: Number.POSITIVE_INFINITY, repeatDelay: 3 }}
+                    >
+                      <MessageSquare className="h-6 w-6 text-brand-teal" />
+                    </motion.div>
+                    <h2 className="text-2xl font-bold text-white">
+                      Want to Learn More About Working Together?
+                    </h2>
+                  </div>
+                  <p className="text-gray-400">
+                    Chat with my AI assistant to explore how we can collaborate on your project
+                  </p>
                 </div>
-                <p className="text-gray-400">
-                  Chat with my AI assistant to explore how we can collaborate on your project
-                </p>
-              </div>
 
-              <Card className="bg-white/5 backdrop-blur-sm border-white/10">
-                <CardContent className="pt-6">
-                  {chatConfig?.enabled !== false && <ChatInterfaceAI {...(chatConfig ?? {})} />}
-                </CardContent>
-              </Card>
-            </motion.div>
+                <Card className="bg-white/5 backdrop-blur-sm border-white/10">
+                  <CardContent className="pt-6">
+                    <ChatInterfaceAI {...(chatConfig ?? {})} />
+                  </CardContent>
+                </Card>
+              </motion.div>
+            )}
           </div>
         </main>
         {footer}
@@ -1021,29 +1023,31 @@ export default function ContactBookingPage({
         </div>
 
         {/* Chat Section - Well Below the Fold */}
-        <div className="px-4 md:px-8 py-16 md:py-24 max-w-7xl mx-auto" data-chat-section>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.5 }}
-            className="max-w-4xl mx-auto"
-          >
-            <div className="flex items-center gap-2 mb-4">
-              <motion.div
-                animate={{ rotate: [0, 10, -10, 0] }}
-                transition={{ duration: 2, repeat: Number.POSITIVE_INFINITY, repeatDelay: 3 }}
-              >
-                <MessageSquare className="h-6 w-6 text-brand-teal" />
-              </motion.div>
-              <h2 className="text-2xl font-bold text-white">Questions? Ask My AI Assistant</h2>
-            </div>
-            <p className="text-gray-400 mb-6">
-              Have questions before booking? Chat with my AI assistant for instant answers about
-              services, availability, and more.
-            </p>
-            {chatConfig?.enabled !== false && <ChatInterfaceAI {...(chatConfig ?? {})} />}
-          </motion.div>
-        </div>
+        {chatConfig?.enabled !== false && (
+          <div className="px-4 md:px-8 py-16 md:py-24 max-w-7xl mx-auto" data-chat-section>
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.5 }}
+              className="max-w-4xl mx-auto"
+            >
+              <div className="flex items-center gap-2 mb-4">
+                <motion.div
+                  animate={{ rotate: [0, 10, -10, 0] }}
+                  transition={{ duration: 2, repeat: Number.POSITIVE_INFINITY, repeatDelay: 3 }}
+                >
+                  <MessageSquare className="h-6 w-6 text-brand-teal" />
+                </motion.div>
+                <h2 className="text-2xl font-bold text-white">Questions? Ask My AI Assistant</h2>
+              </div>
+              <p className="text-gray-400 mb-6">
+                Have questions before booking? Chat with my AI assistant for instant answers about
+                services, availability, and more.
+              </p>
+              <ChatInterfaceAI {...(chatConfig ?? {})} />
+            </motion.div>
+          </div>
+        )}
       </main>
 
       {footer}

--- a/packages/ui/src/toaster.tsx
+++ b/packages/ui/src/toaster.tsx
@@ -7,8 +7,8 @@ import {
   ToastProvider,
   ToastTitle,
   ToastViewport,
-} from '@/components/ui/toast'
-import { useToast } from '@/hooks/use-toast'
+} from './toast'
+import { useToast } from './hooks/use-toast'
 
 export function Toaster() {
   const { toasts } = useToast()


### PR DESCRIPTION
## Problem
On the Wolven Tech `/contact` page: an empty **"Questions? Ask My AI Assistant"** heading + blurb rendered (chat is disabled there), and the **footer appeared twice**.

## Fix
- **AI section** — `ContactBookingPage` gated only the `ChatInterfaceAI` widget on `chatConfig.enabled`, so the surrounding heading/description still rendered when disabled. Wrapped the entire chat section (both the main form view and the success view) in the `enabled !== false` guard. The web app passes `enabled: true`, so it's unaffected.
- **Double footer** — `apps/wolventech/contact` passed `footer={<Footer/>}` while `apps/wolventech/layout.tsx` already renders `<Footer/>` globally. Dropped the prop (and the unused import).

## Verify
Biome + type-check clean. Web app contact (own footer + chat enabled) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)