### PR TITLE
feat: branded newsletter email (real markdown, CTA, unsubscribe)

### DIFF
--- a/apps/web/scripts/publish-blog-post.ts
+++ b/apps/web/scripts/publish-blog-post.ts
@@ -15,7 +15,8 @@
 
 import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
-import { sendNewsletterIssue } from '@decebal/email'
+import { renderNewsletterIssue, sendNewsletterPost } from '@decebal/email'
+import type { NewsletterIssueEmailProps } from '@decebal/email'
 import { createNewsletterIssue, getActiveSubscribers, markIssueSent } from '@decebal/newsletter'
 import { generateOGImageUrl, postToAllPlatforms } from '@decebal/social'
 import matter from 'gray-matter'
@@ -97,21 +98,12 @@ function loadBlogPost(slug: string): BlogPost | null {
 }
 
 /**
- * Convert MDX content to HTML for email
+ * Rewrite root-relative markdown links/images (e.g. `](/blog/x)`) to absolute
+ * URLs so they resolve inside an email client. The branded email template
+ * renders the markdown itself (links, lists, code) — no hand-rolled HTML.
  */
-function mdxToHtml(content: string): string {
-  // Basic MDX to HTML conversion
-  // In production, use a proper MDX parser like @mdx-js/mdx
-  const html = content
-    .replace(/^# (.+)$/gm, '<h1>$1</h1>')
-    .replace(/^## (.+)$/gm, '<h2>$1</h2>')
-    .replace(/^### (.+)$/gm, '<h3>$1</h3>')
-    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-    .replace(/\*(.+?)\*/g, '<em>$1</em>')
-    .replace(/`(.+?)`/g, '<code>$1</code>')
-    .replace(/\n\n/g, '</p><p>')
-
-  return `<p>${html}</p>`
+function absolutizeMarkdownUrls(markdown: string, baseUrl: string): string {
+  return markdown.replace(/\]\(\/(?!\/)/g, `](${baseUrl}/`)
 }
 
 /**
@@ -129,11 +121,24 @@ async function sendNewsletterToSubscribers(
   }
 
   try {
-    // Create newsletter issue (appends issue.created to AllSource)
-    const contentHtml = mdxToHtml(post.content)
+    // Build the branded email once: real Markdown body + absolute links + CTA.
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://decebaldobrica.com'
+    const postUrl = `${baseUrl}/blog/${post.slug}`
+    const issueProps: NewsletterIssueEmailProps = {
+      title: post.title,
+      preview: post.excerpt,
+      markdown: absolutizeMarkdownUrls(post.content, baseUrl),
+      postUrl,
+      kicker: post.tags[0] ?? 'New post',
+      unsubscribeUrl: `${baseUrl}/newsletter/unsubscribe`,
+    }
+    const subject = `New Post: ${post.title}`
+
+    // Store the exact HTML that subscribers receive on the AllSource issue event.
+    const contentHtml = await renderNewsletterIssue(issueProps)
     const issue = await createNewsletterIssue({
       title: post.title,
-      subject: `New Post: ${post.title}`,
+      subject,
       preview_text: post.excerpt,
       content_html: contentHtml,
       content_text: post.content,
@@ -161,7 +166,6 @@ async function sendNewsletterToSubscribers(
         .join(', ')}`
     )
 
-    const subject = `New Post: ${post.title}`
     let sent = 0
     let errors = 0
 
@@ -177,7 +181,7 @@ async function sendNewsletterToSubscribers(
       // In test-recipient mode, never send to the real subscriber list.
       const recipient = guard.testRecipient ?? subscriber.email
       try {
-        const result = await sendNewsletterIssue(recipient, subject, contentHtml)
+        const result = await sendNewsletterPost(recipient, subject, issueProps)
         if (result.success) {
           sent++
           process.stdout.write('.')

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,10 +1,13 @@
 // Email templates
 export { NewsletterConfirmationEmail } from './newsletter-confirmation'
 export { NewsletterWelcomeEmail } from './newsletter-welcome'
+export { NewsletterIssueEmail, type NewsletterIssueEmailProps } from './newsletter-issue'
 
 // Email sending functions
 export {
   sendNewsletterConfirmation,
   sendNewsletterWelcome,
   sendNewsletterIssue,
+  sendNewsletterPost,
+  renderNewsletterIssue,
 } from './send'

--- a/packages/email/src/newsletter-issue.tsx
+++ b/packages/email/src/newsletter-issue.tsx
@@ -1,0 +1,288 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Markdown,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+import * as React from 'react'
+
+export interface NewsletterIssueEmailProps {
+  /** Post title — rendered as the email's headline. */
+  title: string
+  /** Inbox preview snippet (excerpt). */
+  preview: string
+  /** Post body as Markdown. Links should already be absolute URLs. */
+  markdown: string
+  /** Absolute URL to the full post on the web. */
+  postUrl: string
+  /** Small eyebrow above the title, e.g. a series name. */
+  kicker?: string
+  /** Absolute unsubscribe URL. */
+  unsubscribeUrl?: string
+}
+
+export function NewsletterIssueEmail({
+  title,
+  preview,
+  markdown,
+  postUrl,
+  kicker = 'New post',
+  unsubscribeUrl = 'https://decebaldobrica.com/newsletter/unsubscribe',
+}: NewsletterIssueEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>{preview}</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          {/* Branded header */}
+          <Section style={header}>
+            <Text style={logo}>DECEBAL DOBRICA</Text>
+            <Text style={headerTagline}>Rust · Event Sourcing · Engineering Leadership</Text>
+          </Section>
+
+          {/* Title block */}
+          <Section style={titleBlock}>
+            <Text style={eyebrow}>{kicker.toUpperCase()}</Text>
+            <Heading style={h1}>{title}</Heading>
+          </Section>
+
+          {/* Body — real Markdown: links, lists, headings, code all render */}
+          <Section style={bodySection}>
+            <Markdown markdownContainerStyles={markdownContainer} markdownCustomStyles={mdStyles}>
+              {markdown}
+            </Markdown>
+          </Section>
+
+          {/* Primary CTA */}
+          <Section style={ctaContainer}>
+            <Button style={button} href={postUrl}>
+              Read the full post →
+            </Button>
+            <Text style={ctaSub}>
+              Or paste this into your browser:{' '}
+              <Link href={postUrl} style={ctaLink}>
+                {postUrl.replace(/^https?:\/\//, '')}
+              </Link>
+            </Text>
+          </Section>
+
+          {/* Reply prompt — the series invites reader requests */}
+          <Section style={replySection}>
+            <Hr style={hr} />
+            <Text style={replyText}>
+              Hit reply and tell me what you want covered — reader requests shape the backlog.
+            </Text>
+          </Section>
+
+          {/* Footer */}
+          <Section style={footerBanner}>
+            <Link href="https://decebaldobrica.com" style={footerLink}>
+              <Text style={footerBrandText}>decebaldobrica.com</Text>
+            </Link>
+            <Text style={footerSocial}>
+              <Link href="https://github.com/decebal" style={socialLink}>
+                GitHub
+              </Link>{' '}
+              ·{' '}
+              <Link href="https://www.linkedin.com/in/decebaldobrica/" style={socialLink}>
+                LinkedIn
+              </Link>{' '}
+              ·{' '}
+              <Link href="https://x.com/ddonprogramming" style={socialLink}>
+                Twitter
+              </Link>
+            </Text>
+            <Text style={footerUnsubscribe}>
+              You're receiving this because you subscribed at decebaldobrica.com.{' '}
+              <Link href={unsubscribeUrl} style={unsubscribeLink}>
+                Unsubscribe
+              </Link>
+              .
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+
+export default NewsletterIssueEmail
+
+// ---- styles ----
+const TEAL = '#03c9a9'
+const INK = '#111827'
+
+const main = {
+  backgroundColor: '#f6f9fc',
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
+}
+
+const container = {
+  backgroundColor: '#ffffff',
+  margin: '0 auto',
+  marginBottom: '64px',
+  maxWidth: '600px',
+  borderRadius: '12px',
+  overflow: 'hidden',
+  boxShadow: '0 4px 16px rgba(0, 0, 0, 0.08)',
+}
+
+const header = {
+  background: `linear-gradient(135deg, ${TEAL} 0%, #059669 100%)`,
+  padding: '28px 48px',
+  textAlign: 'center' as const,
+}
+
+const logo = {
+  color: '#ffffff',
+  fontSize: '22px',
+  fontWeight: 'bold',
+  letterSpacing: '1.5px',
+  margin: '0',
+}
+
+const headerTagline = {
+  color: 'rgba(255,255,255,0.92)',
+  fontSize: '13px',
+  margin: '6px 0 0 0',
+}
+
+const titleBlock = {
+  padding: '36px 48px 8px 48px',
+}
+
+const eyebrow = {
+  color: TEAL,
+  fontSize: '12px',
+  fontWeight: 'bold',
+  letterSpacing: '1.5px',
+  margin: '0 0 10px 0',
+}
+
+const h1 = {
+  color: INK,
+  fontSize: '28px',
+  lineHeight: '34px',
+  fontWeight: 'bold',
+  margin: '0',
+}
+
+const bodySection = {
+  padding: '8px 48px 0 48px',
+}
+
+const markdownContainer = {
+  padding: '0',
+}
+
+const mdStyles = {
+  h1: { color: INK, fontSize: '24px', fontWeight: 'bold', margin: '28px 0 12px' },
+  h2: { color: INK, fontSize: '20px', fontWeight: 'bold', margin: '26px 0 10px' },
+  h3: { color: INK, fontSize: '17px', fontWeight: 'bold', margin: '22px 0 8px' },
+  p: { color: '#374151', fontSize: '16px', lineHeight: '27px', margin: '14px 0' },
+  li: { color: '#374151', fontSize: '16px', lineHeight: '26px', margin: '6px 0' },
+  link: { color: TEAL, textDecoration: 'underline' },
+  bold: { color: INK, fontWeight: 'bold' },
+  codeInline: {
+    backgroundColor: '#f3f4f6',
+    color: '#9333ea',
+    padding: '2px 6px',
+    borderRadius: '4px',
+    fontSize: '14px',
+    fontFamily: 'ui-monospace,SFMono-Regular,Menlo,monospace',
+  },
+  blockQuote: {
+    borderLeft: `3px solid ${TEAL}`,
+    paddingLeft: '16px',
+    margin: '18px 0',
+    color: '#4b5563',
+    fontStyle: 'italic',
+  },
+}
+
+const ctaContainer = {
+  padding: '28px 48px 8px 48px',
+}
+
+const button = {
+  backgroundColor: TEAL,
+  borderRadius: '10px',
+  color: '#ffffff',
+  fontSize: '16px',
+  fontWeight: 'bold',
+  textDecoration: 'none',
+  textAlign: 'center' as const,
+  display: 'block',
+  padding: '15px 28px',
+  boxShadow: '0 3px 8px rgba(3,201,169,0.35)',
+}
+
+const ctaSub = {
+  color: '#9ca3af',
+  fontSize: '12px',
+  textAlign: 'center' as const,
+  margin: '12px 0 0 0',
+}
+
+const ctaLink = {
+  color: '#6b7280',
+  textDecoration: 'underline',
+}
+
+const replySection = {
+  padding: '8px 48px 24px 48px',
+}
+
+const hr = {
+  borderColor: '#e5e7eb',
+  margin: '20px 0',
+}
+
+const replyText = {
+  color: '#4b5563',
+  fontSize: '15px',
+  lineHeight: '24px',
+  margin: '0',
+}
+
+const footerBanner = {
+  backgroundColor: '#111827',
+  padding: '28px 48px',
+  textAlign: 'center' as const,
+}
+
+const footerLink = { textDecoration: 'none' }
+
+const footerBrandText = {
+  color: TEAL,
+  fontSize: '18px',
+  fontWeight: 'bold',
+  margin: '0 0 12px 0',
+}
+
+const footerSocial = {
+  color: '#9ca3af',
+  fontSize: '13px',
+  margin: '8px 0',
+}
+
+const socialLink = { color: '#d1d5db', textDecoration: 'none' }
+
+const footerUnsubscribe = {
+  color: '#6b7280',
+  fontSize: '12px',
+  lineHeight: '18px',
+  margin: '14px 0 0 0',
+}
+
+const unsubscribeLink = { color: '#9ca3af', textDecoration: 'underline' }

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -1,6 +1,7 @@
 import { render } from '@react-email/render'
 import { Resend } from 'resend'
 import { NewsletterConfirmationEmail } from './newsletter-confirmation'
+import { NewsletterIssueEmail, type NewsletterIssueEmailProps } from './newsletter-issue'
 import { NewsletterWelcomeEmail } from './newsletter-welcome'
 
 let resend: Resend | null = null
@@ -104,8 +105,49 @@ export async function sendNewsletterWelcome(
 }
 
 /**
- * Send newsletter issue to subscribers
- * This will be used in Phase 5 for publishing blog posts
+ * Render the branded newsletter-issue email to HTML. Exposed so callers can
+ * store the exact HTML that gets sent (e.g. on the AllSource issue event).
+ */
+export function renderNewsletterIssue(props: NewsletterIssueEmailProps): Promise<string> {
+  return render(NewsletterIssueEmail(props))
+}
+
+/**
+ * Send a blog post to a subscriber as a fully branded newsletter issue:
+ * gradient header, real Markdown body (links/lists/code), a "Read the full
+ * post" CTA, and a footer with unsubscribe. Replaces the old raw-HTML path.
+ */
+export async function sendNewsletterPost(
+  email: string,
+  subject: string,
+  props: NewsletterIssueEmailProps
+): Promise<SendEmailResult> {
+  try {
+    const html = await renderNewsletterIssue(props)
+    const { data, error } = await getResendClient().emails.send({
+      from: process.env.EMAIL_FROM || 'Decebal Dobrica <newsletter@decebaldobrica.com>',
+      to: email,
+      subject,
+      html,
+    })
+
+    if (error) {
+      console.error('[Email] Failed to send newsletter post:', error)
+      return { success: false, error: error.message || 'Failed to send newsletter post' }
+    }
+    return { success: true, id: data?.id }
+  } catch (error) {
+    console.error('[Email] Unexpected error sending newsletter post:', error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    }
+  }
+}
+
+/**
+ * Send newsletter issue to subscribers (raw pre-rendered HTML).
+ * Prefer sendNewsletterPost() for blog posts — it applies the branded template.
  */
 export async function sendNewsletterIssue(
   email: string,


### PR DESCRIPTION
## Problem
The published newsletter was bland and broken: the publish flow ran `mdxToHtml()` — a 6-regex toy that **dropped links and lists** — and sent the raw output untemplated. Result: a full-bleed `<p>` dump with literal `[Toasty](/blog/...)` markdown (broken, relative URL), bullet lists mashed into run-on text, no CTA, no branding, and **no unsubscribe** (CAN-SPAM gap).

## Fix — branded React Email template
- New `NewsletterIssueEmail` (`@react-email/components`): gradient header, eyebrow/kicker, headline, a `<Markdown>` body that properly renders **links, lists, headings, code, blockquotes**, a prominent **"Read the full post →"** CTA, a reply prompt, and a footer with social links + **unsubscribe**.
- New `renderNewsletterIssue()` / `sendNewsletterPost()` in `@decebal/email`.
- Rewire `publish-blog-post.ts`: drop `mdxToHtml`, **absolutize root-relative URLs** (`](/blog/x)` → full URL), send the branded issue, and store the *same* HTML on the AllSource `issue.created` event.

## Verified
Rendered the real Rust Crate Radar post through the template (headless screenshot in the task):
- Toasty link is absolute + clickable (no literal `[Toasty]`)
- `<ul>/<li>` lists render (rubric + formats no longer run-on)
- CTA button + unsubscribe present
- Biome + email-package type-check clean

Before: untemplated text dump. After: branded, scannable, with a working CTA and unsubscribe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)