### PR TITLE
fix: booking 'Invalid meeting type' on contact form

### DIFF
--- a/packages/booking/src/server/meeting.ts
+++ b/packages/booking/src/server/meeting.ts
@@ -129,7 +129,14 @@ export function createMeetingActions(ctx: BookingContext) {
         }
       }
 
-      const meetingConfig = MEETING_TYPES[meetingType]
+      // The client sends the display name (config.name) as meetingType, while
+      // MEETING_TYPES is keyed by slug. Resolve by key first, then fall back to
+      // matching name or slug so either identifier validates.
+      const meetingConfig =
+        MEETING_TYPES[meetingType] ??
+        Object.values(MEETING_TYPES).find(
+          (c) => c.name === meetingType || c.slug === meetingType
+        )
       if (!meetingConfig) {
         return { success: false, error: 'Invalid meeting type' }
       }


### PR DESCRIPTION
## Problem
Every contact-form booking failed with **"Booking Failed — Invalid meeting type."**

## Root cause
`ContactBookingPage` maps each meeting with `meetingType: config.name` (e.g. `"Quick Chat (15 min)"`) and submits that, but the server validated via `MEETING_TYPES[meetingType]` — a record **keyed by slug** (`"quick-chat-15min"`). Name ≠ key → `undefined` → "Invalid meeting type".

## Fix
Server resolves the config by key first, then falls back to matching `name` or `slug`, so either identifier validates. Downstream already uses `meetingConfig.name`, so it's non-breaking. Fix is in the shared `@decebal/booking` package, so it covers wolventech **and** the web app contact forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)