### PR TITLE
fix: wolventech contact — back-to-services 404 + orphan scroll chevron

### DIFF
--- a/apps/web/content/blog/2026-06-13-smb2-pure-rust-smb-client.mdx
+++ b/apps/web/content/blog/2026-06-13-smb2-pure-rust-smb-client.mdx
@@ -1,0 +1,81 @@
+---
+title: 'smb2: The Pure-Rust SMB Client That Outruns macOS''s Own'
+date: '2026-06-13T12:00:00.000Z'
+author: Decebal D.
+description: "A months-old, pure-Rust SMB2/3 client beats the native macOS file client on a NAS and is tested harder than most funded libraries. Should it be in your stack yet? The Crate Radar verdict: Trial."
+tags:
+  - rust
+  - crates
+  - smb
+  - networking
+  - dependency-management
+  - crate-radar
+slug: 2026-06-13-smb2-pure-rust-smb-client
+---
+
+Copy a few gigabytes off a network drive and you quietly accept a speed limit — whatever your operating system's own file client can manage feels like a law of nature.
+
+On a Gigabit NAS, [smb2](https://github.com/vdavid/smb2) breaks that law. The pure-Rust SMB client, in [benchmarks its author published](https://www.veszelovszki.com/a/smb2/), beats the *native macOS* SMB client on every operation — by as much as 5× on downloads — and it has only been on [crates.io](https://crates.io/crates/smb2) since April.
+
+That alone makes it worth a look. What makes it worth a *verdict* is everything around the speed: a test suite most funded libraries would envy, a refreshingly honest list of limitations, and a provenance question every engineering leader now has to weigh.
+
+> **TL;DR — Trial.** Put smb2 on a real but non-critical path today. The thing keeping it from a clean "Adopt" isn't the code; it's the bus factor.
+
+*(This is a [Rust Crate Radar](/blog/2026-06-10-introducing-rust-crate-radar) Deep Dive — every verdict is checked against the crate's live maintenance and activity, not vibes.)*
+
+## What it actually is
+
+smb2 is an async, runtime-agnostic SMB 2.x/3.x client written straight from Microsoft's [MS-SMB2 specification](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/). There is no C library underneath it and no SMB1 — a deliberate, security-minded omission. Talking to a Windows share or a Samba server from Rust used to mean binding to a C client; smb2 makes it a pure-Cargo dependency.
+
+The API is the boring kind, which is a compliment:
+
+```rust
+let mut client = smb2::connect(&addr, &user, &pass).await?;
+let mut share = client.connect_share("Documents").await?;
+let data = client.read_file(&mut share, "report.pdf").await?;
+```
+
+A runnable version lives in the series' examples repo, on the [Digest #1 branch](https://github.com/decebal/rust-crate-radar/tree/rust-crate-radar-digest-001/examples/smb2).
+
+## The benchmark that earns attention
+
+> On a Gigabit NAS, smb2 beats the native macOS SMB client on every operation — and runs 3–8× faster than the existing `smb` crate.
+
+The speed isn't an accident of micro-optimization; it's architectural. smb2 pipelines its I/O — it batches compound requests and rides a sliding window with adaptive chunking, so it isn't idling between round-trips the way a request-response client does. On a high-latency or lossy link, that design is the difference, and it's exactly where a from-the-spec implementation can out-engineer a decades-old default.
+
+## What actually earns the verdict: the testing
+
+Speed is easy to stage in a benchmark; durability is not. The reason smb2 reaches **Trial** rather than **Assess** is its test discipline, which is unusual for a crate this young: roughly 970 tests, property tests, 12 fuzz targets, and — the part worth pausing on — integration tests against **14 Docker-based Samba containers** in CI, covering encryption-required servers, high latency, dropped connections, and tiny read sizes. A `testing` feature lets *your* application spin up the same containers, so you can prove the integration against your own access patterns before you commit.
+
+That is more rigor than many funded, decade-old libraries carry. It is the single strongest signal that this isn't a weekend project.
+
+## The catch
+
+Two things hold smb2 back from a clean "Adopt," and the author is upfront about both.
+
+It is a **single maintainer** — [David Veszelovszki](https://www.veszelovszki.com/) — which is real bus-factor risk for anything you'd build a product on. And it was written with heavy AI assistance, stated plainly in the project's own notes. The test suite above is precisely what makes that provenance defensible: the code is held to spec by machinery, not vibes. But "one person, AI-assisted" is a profile to weigh deliberately, not wave through.
+
+It is also **not yet feature-complete** against its older rival. The more established [`smb`](https://crates.io/crates/smb) crate has multi-channel and QUIC/RDMA support that smb2 omits. If you need those, this isn't your client yet.
+
+## Evaluation
+
+Run smb2 through the Crate Radar [evaluation tool](https://github.com/decebal/rust-crate-radar) and the maintenance picture is healthy, which is what tips the trade-offs toward Trial rather than Assess:
+
+- **Problem fit — Strong.** Pure-Rust SMB with no C dependency is a real, under-served need.
+- **Maturity — Early.** `0.11.3`, pre-1.0, first published April 2026; expect breaking changes.
+- **Activity — Active.** Last commit six days ago; eleven releases in the past year.
+- **Stewardship — Watch.** Single maintainer, AI-assisted; offset by an exceptional test suite.
+- **Ecosystem fit — Strong.** Async and runtime-agnostic; MSRV 1.85; dual MIT/Apache.
+- **Exit cost — Low.** A client behind a thin call surface; swapping it back out is cheap.
+
+## The verdict
+
+**Trial.** If you touch SMB from Rust, put smb2 on a real but non-critical path now — a sync job, an internal tool, an importer — and lean on its container test harness to prove it against your servers. The benchmarks are real and the testing is better than its age suggests.
+
+The one thing to keep your eye on isn't a line of code. It's whether a second maintainer ever shows up. The day this stops being one person's project is the day it graduates to Adopt.
+
+---
+
+*Next on the Radar: a Category Showdown of async runtimes. Got a crate you want put under the tool? [Get in touch](/contact).*
+
+**Sources:** [smb2 on GitHub](https://github.com/vdavid/smb2) · [crates.io](https://crates.io/crates/smb2) · [author's benchmarks & write-up](https://www.veszelovszki.com/a/smb2/)

--- a/apps/web/content/blog/2026-06-17-past-the-loop-claude-code-tooling-stack.mdx
+++ b/apps/web/content/blog/2026-06-17-past-the-loop-claude-code-tooling-stack.mdx
@@ -1,0 +1,156 @@
+---
+title: 'Past the 9-Step Loop: The Claude Code Stack That Actually Makes Agents Senior'
+date: '2026-06-17T09:00:00.000Z'
+author: Decebal D.
+description: "A widely-shared thread argues Claude Code becomes a senior engineer once you wrap it in a 9-step loop built from plan mode, subagents, hooks, CLAUDE.md, and slash commands. The loop is right and necessary — but it quietly assumes infinite context, perfect memory, and that an in-session reviewer is enough. Here's the tooling layer that makes the loop actually run on a real codebase: chronis, AllSource Prime, caveman, rtk, CodeRabbit, and pixel-perfect overlays."
+tags:
+  - claude-code
+  - ai-agents
+  - developer-tools
+  - agentic-ai
+  - rust
+  - tooling
+  - workflow
+  - event-sourcing
+slug: 2026-06-17-past-the-loop-claude-code-tooling-stack
+---
+
+> A response to [0xMorty's "The 9-Step Loop That Turns Claude Code Into a Senior Engineer"](https://x.com/0xMortyx/status/2066469702075920794) (77K+ views, and deservedly so). I agree with almost all of it. This is the *yes, and* — the part the thread leaves out, which is the part that actually decides whether the loop survives contact with a production codebase.
+
+## The thread is right. That's the problem.
+
+The viral version of the argument goes like this: the model was always capable; what was missing was the **loop** around it. Explore, plan, build small, enforce with hooks, test, review with a second agent, fix and re-check, ship with a slash command. Wire Claude Code's built-in primitives together and a junior-tier setup becomes a senior-tier one.
+
+I've run that loop. It works. If you take nothing else from either post, take the discipline: never let it build before you've seen the plan, make the important rules deterministic, and don't trust a diff that hasn't been tested. That's correct and most people don't do it.
+
+But "the loop is the difference, not the model" is only half true, and the missing half is where all the real engineering lives. A loop is **control flow**. It says *what order* the steps run in. It says nothing about whether each step can actually execute on a 400-file codebase, across a week of work, without the agent running out of context, forgetting why it made a decision three sessions ago, or shipping a diff that two LLMs both rationalized past.
+
+The 9-step loop quietly assumes three things that are false on any real project:
+
+1. **Context is free.** Explore + plan + build + test + review + re-review is six-plus full passes over your code, every task. On a real repo that's not a workflow, it's a token bonfire — and it hits the context window long before it hits "done."
+2. **Memory persists.** Plan mode and `CLAUDE.md` live for exactly one session. The moment you `/compact` or close the terminal, the *why* behind every decision evaporates. The agent re-explores the same code tomorrow because it has no durable memory of having understood it yesterday.
+3. **An in-session reviewer is enough.** A "review subagent" with a clean context window is better than nothing. But it runs in the same environment, on the same model, against the same blind spots, and on *your* token budget. It is not an independent reviewer. It is the same engineer wearing a fake moustache.
+
+The loop is the floor. The thing that turns it from a clever demo into a workflow you can run fifty times a day is the **tooling layer** underneath it. Here's mine.
+
+## The loop's hidden assumptions, and what fixes each
+
+| The thread's step | The hidden assumption | What actually fixes it |
+|---|---|---|
+| 1. Explore the codebase | Re-explore every session, for free | **AllSource Prime** — durable, queryable memory of what the code *is* and why |
+| 2. Plan in plan mode | The plan lives one session | **chronis** — the plan becomes an event-sourced task graph that outlives the window |
+| 3. Standards in `CLAUDE.md` | Advisory text the model reads | **AllSource Prime** — decisions/ADRs stored with provenance, recalled on demand |
+| 4. Build small pieces | The agent reads its own state cheaply | **chronis `--toon`** — task state at ~50% fewer tokens |
+| 5. Enforce with hooks | Hooks just run lint/tests | Hooks also run **rtk** + **caveman** so the loop stays affordable |
+| 6. Prove it with tests | Tests are the ceiling of verification | **CodeRabbit** — independent review on the PR, outside your context |
+| 7. Second-agent review | A sibling LLM is "independent" | **CodeRabbit** — different system, different budget, doesn't share your blind spots |
+| 8. Fix and re-check | "Undo" is re-opening a task by hand | **chronis** temporal replay — reconstruct any prior state from the event stream |
+| 9. Ship with a slash command | Shipping code is the finish line | **Pixel Perfect** — the missing step: does the *rendered UI* match the design? |
+
+The rest of this post is that table, with receipts.
+
+## Layer 1 — The token economy: caveman + rtk
+
+Start here, because nothing else matters if you can't afford to run the loop.
+
+The 9-step loop is *expensive by design*. Every task does multiple full passes over your code. The honest math: a disciplined loop on a non-trivial change can burn more tokens on **process** — exploring, planning, reviewing, re-reviewing — than on the actual change. Do that on every task and you either hit the context ceiling mid-loop or you watch your bill detonate. Most people quietly abandon the discipline for exactly this reason. The loop didn't fail; it got too costly to keep running.
+
+Two tools attack the two biggest sources of waste.
+
+[**caveman**](https://github.com/juliusbrussee/caveman) is a Claude Code skill that rewrites the model's *own output* to be terse — "why use many token when few token do trick." It cuts roughly 65–75% of output tokens without touching the reasoning. As its author puts it: *"Caveman no make brain smaller. Caveman make mouth smaller."* The agent still thinks in full; it just stops narrating every thought in three paragraphs of prose you were going to skim anyway.
+
+**rtk** (Rust Token Killer) attacks the other end: terminal output. Bash output is the cheapest and biggest source of wasted context there is — a single `npm test` or `cargo build` can dump thousands of tokens of progress bars, stack traces, and noise straight into the window. rtk is a small Rust binary that pipes that output through a filter *before* it enters context. In a loop where step 5 runs lint and tests on every edit (per the thread's own advice), this is the difference between a hook that helps and a hook that floods.
+
+Wire both into the loop's hooks and the economics flip: now you can actually afford to explore-plan-build-test-review-rereview, because each pass costs a fraction of what the naive version does.
+
+## Layer 2 — Durable memory and task state: chronis + AllSource Prime
+
+This is the layer the thread is most missing, and the one I care most about — partly because [chronis](https://crates.io/crates/chronis) and [AllSource](https://all-source.xyz) are my own projects, so read this section knowing I built the tools I'm recommending. The argument stands on its own; the disclosure is owed.
+
+The thread's plan and standards steps live and die inside one session. Plan mode produces a plan you approve — and then it's gone. `CLAUDE.md` is, in the thread's own words, *advisory*; the model reads it most of the time. Neither survives a `/compact`. On a multi-day feature, the agent has no idea what it decided on Monday by the time it's coding on Wednesday.
+
+[**chronis**](https://crates.io/crates/chronis) turns the plan into something durable. It's an agent-native, **event-sourced** task CLI (the binary is `cn`). Every action — create, claim, done, approve, add a dependency — is an immutable event; current state is a projection folded from that stream. That gives you things plan mode structurally cannot:
+
+- **Temporal replay.** Agent closed the wrong task? You don't manually re-open it — you reconstruct state at any prior point from the event stream. The thread's "fix and re-check" step gets a real undo.
+- **Cascade operations.** `cn done <epic-id> --cascade` closes an epic and all its children in one command, instead of scripting N calls.
+- **TOON output.** This is the signature feature, and it ties straight back to Layer 1. Pass `--toon` to any command and you get [Token-Oriented Object Notation](https://github.com/toon-format/toon) instead of an ASCII table. A `cn list` that costs ~180 tokens of box-drawing characters becomes ~60 tokens of pipe-delimited rows — same information, ~50% fewer tokens, parsed natively by the model. When the agent reads its own task list dozens of times a session, that compounds.
+- **HTTP sync, no git.** State syncs to a remote Core over HTTP, so it works with a dirty worktree and never stalls on a merge conflict.
+
+So the "plan" stops being a one-session artifact and becomes a queryable, replayable, agent-readable task graph that any session can pick up cold.
+
+**AllSource Prime** is the other half: the semantic memory. Where chronis remembers *what work happened*, Prime remembers *what the system is and why*. It's a knowledge-graph memory layer — hybrid recall over vectors plus graph expansion plus temporal recency — that you query for "what do I know about X?" across sessions. Decisions, ADRs, the shape of the auth flow, the reason a fragile module is fragile: stored with provenance, recalled on demand. That's what the thread's "explore the codebase" step *should* produce — not a throwaway summary that dies at session end, but an accumulating model the agent consults instead of re-deriving.
+
+Put bluntly: plan mode + `CLAUDE.md` is the agent's short-term memory. chronis + Prime is its long-term memory. A senior engineer's value is mostly long-term memory — they remember why the thing is the way it is. You can't get senior behavior from an agent with anterograde amnesia, no matter how good the loop is.
+
+## Layer 3 — Independent verification: CodeRabbit
+
+The thread's step 7 is the right instinct executed in the wrong place. "Spin up a review subagent with a clean context window" — yes, fresh eyes catch what the builder rationalized past. But a subagent is not independent in any way that matters:
+
+- It runs **on the same model**, so it shares the builder's blind spots.
+- It runs **in the same session**, on **your token budget**, so a thorough review competes for context with the work itself.
+- It's **non-deterministic** — review quality varies run to run, and there's no audit trail.
+
+[**CodeRabbit**](https://www.coderabbit.ai/) is what step 7 actually wants: an independent reviewer that lives **outside** your Claude Code session, on the pull request. It reviews every PR automatically, posts line-level comments, understands the diff in the context of the whole repo, and — critically — doesn't spend a single token of your agent's context window to do it. It's the human-team code-review model applied honestly: the reviewer didn't write the code, isn't in the author's head, and produces a durable, reviewable record on the PR itself.
+
+Use the in-session subagent as a cheap first pass if you like. But the review that decides whether you ship should come from a system that doesn't share your agent's mind. That's not a nuance — it's the whole reason code review works for human teams.
+
+## Layer 4 — The step the loop doesn't have: pixel-perfect verification
+
+Here's the gap that should bother anyone who builds front-end work with agents: the entire 9-step loop can pass, tests green, both reviewers happy — and the UI can still be visibly wrong. Tests assert behavior. LLM review reads code. **Neither of them looks at the rendered pixels.** An agent will confidently report "matches the design" while the button sits 8px too low, the font weight is off, and the spacing drifted three commits ago.
+
+A **pixel-perfect browser extension** (the [PerfectPixel](https://www.welldonecode.com/perfectpixel/)-style overlay tools) closes that gap the way a real front-end engineer does: it overlays the actual design comp on top of the running app at adjustable opacity, so the difference between intended and rendered is *visible*, to the pixel. It's the ground-truth check that no amount of "looks good to me" — from a human or a model — substitutes for. This is the missing tenth step: not "ship it," but "verify the artifact against reality before you ship it." For UI work, this is where "done" is actually earned.
+
+## The loop, with the stack wired in
+
+Same discipline the thread preaches. The difference is what each step stands on:
+
+```bash
+# /ship — the senior loop, on a real stack
+
+# 0. Recall: what do we already know? (AllSource Prime — don't re-explore)
+#    query Prime for the subsystem before touching anything
+
+# 1. Plan as durable, replayable task state (chronis)
+cn task create "Add rate limiting" -p p0 --type=epic
+cn task create "Token bucket middleware" --parent=<epic> --toon
+
+# 2. Build small pieces; agent reads its own state cheaply
+cn ready --toon            # ~60 tokens, not ~180
+cn claim <id> --toon
+
+# 3. Enforce non-negotiables AND keep the loop affordable (hooks)
+#    PostToolUse: rtk filters test/build output, caveman trims agent prose,
+#    then lint + tests run deterministically
+
+# 4. Close the task with a full event trail (temporal replay if wrong)
+cn done <id> --toon
+
+# 5. Independent review OUTSIDE the session (CodeRabbit on the PR)
+
+# 6. For UI: overlay the design comp, verify to the pixel (Pixel Perfect)
+
+# 7. Ship — and the durable artifact is the event history + memory graph,
+#    not a one-shot command you'll never read again
+```
+
+The loop didn't change. What changed is that every step now rests on something that survives the session, costs a fraction of the tokens, and verifies against reality instead of against another guess.
+
+## Where the bare loop is genuinely enough (the honest part)
+
+I'd be doing exactly what I'm criticizing if I sold you a heavier stack as a universal mandate. It isn't.
+
+- **For a one-file script, a throwaway prototype, or a quick fix, the bare 9-step loop is the right amount of process.** Standing up event-sourced task tracking and a memory graph to rename a function is its own kind of malpractice.
+- **The stack has real setup and operating costs.** caveman and rtk trade a little output fidelity for tokens — occasionally you want the verbose version back. CodeRabbit is a paid service. Pixel-perfect overlays only help front-end work. chronis and AllSource are early and, again, mine — adopt them with the same skepticism you'd apply to any dependency from someone with an interest in your saying yes.
+- **The thread's primitives are the foundation, not the enemy.** Hooks, plan mode, subagents, and `CLAUDE.md` are exactly where this stack plugs in. I'm not replacing the loop. I'm giving it a substrate.
+
+The counter-argument deserves a fair hearing: maybe context windows keep growing, native memory keeps improving, and in a year the model remembers everything and reviews itself well enough that half this tooling is redundant. Possible. But "the constraints will disappear eventually" is not a plan for shipping this quarter, and every one of these constraints is biting *today*.
+
+## The actual difference
+
+The thread says the difference between a junior-tier and senior-tier setup is the loop, not the model. I'd put it one level deeper: the model was never the bottleneck, and neither is the loop. **The substrate is.** Tokens, memory, and independent verification are the three things that decide whether a disciplined workflow survives a real codebase — and the loop, on its own, addresses none of them.
+
+Build the loop. It's necessary. Then give it a stack that makes it affordable to run, durable across sessions, and honest about whether the work is actually done. That's the part that turns a senior-engineer *demo* into a senior-engineer *workflow*.
+
+---
+
+*Tools referenced: [chronis](https://crates.io/crates/chronis) and [AllSource](https://all-source.xyz) (my own projects — disclosed above), [caveman](https://github.com/juliusbrussee/caveman) and rtk by [@JuliusBrussee](https://github.com/juliusbrussee), [CodeRabbit](https://www.coderabbit.ai/), and [PerfectPixel](https://www.welldonecode.com/perfectpixel/)-style overlay extensions. Original thread: [0xMorty](https://x.com/0xMortyx/status/2066469702075920794).*

--- a/apps/web/content/blog/_2026-06-17-past-the-loop-x-reply.md
+++ b/apps/web/content/blog/_2026-06-17-past-the-loop-x-reply.md
@@ -1,0 +1,72 @@
+# X reply draft — long-form post
+
+> Internal draft (underscore prefix keeps it out of the blog index). Reply to https://x.com/0xMortyx/status/2066469702075920794
+> Posting mode: DRAFT ONLY — paste and post manually.
+> Canonical link: https://decebaldobrica.com/blog/2026-06-17-past-the-loop-claude-code-tooling-stack
+> (verify the live slug/route before posting)
+
+---
+
+## Option A — Long-form post (X Premium, ~580 words)
+
+This is the best thread on Claude Code I've read in a while, and I still think it's only half the story.
+
+The argument: the model was always capable; the difference is the *loop* — explore, plan, build small, enforce with hooks, test, review with a second agent, fix, ship. All correct. Most people don't do any of it.
+
+But a loop is control flow. It tells you what order the steps run in. It says nothing about whether each step can actually execute on a 400-file repo, across a week, without the agent running out of context or forgetting why it made a decision three sessions ago.
+
+The 9-step loop quietly assumes three things that are false on real work:
+
+1/ Context is free. Explore + plan + build + test + review + re-review is 6+ full passes over your code, every task. On a real repo that's a token bonfire — and it hits the context window before it hits "done."
+
+2/ Memory persists. Plan mode and CLAUDE.md live for exactly one session. The moment you /compact, the *why* behind every decision is gone. The agent re-explores the same code tomorrow.
+
+3/ An in-session reviewer is independent. A review subagent runs on the same model, in the same session, on your token budget, against the same blind spots. It's the same engineer in a fake moustache.
+
+The loop is the floor. Here's the layer that makes it actually run:
+
+→ Token economy: caveman (trims the agent's own output ~65-75%) + rtk/Rust Token Killer (filters terminal output before it hits context). The loop is only affordable if each pass is cheap. Most people abandon the discipline because it got too expensive — not because it failed.
+
+→ Durable memory: chronis, an event-sourced task CLI — the plan becomes a replayable task graph that outlives the session, with TOON output that's ~50% fewer tokens than an ASCII table. Plus AllSource Prime, a knowledge-graph memory layer that remembers what the system is and *why*, across sessions. (Both are mine — disclosing that up front.) Plan mode is short-term memory. This is long-term. Senior engineers are mostly long-term memory.
+
+→ Independent review: CodeRabbit, on the PR, outside your session — different system, doesn't share your agent's blind spots, doesn't spend your context budget. That's what "second reviewer" actually means.
+
+→ The step the loop doesn't have: pixel-perfect verification. Tests assert behavior, LLM review reads code — neither looks at the rendered pixels. A pixel-perfect overlay shows the design vs. the running app to the pixel. For UI, that's where "done" is earned.
+
+The honest part: for a quick fix, the bare loop is the right amount of process. The stack has real costs. The thread's primitives — hooks, plan mode, subagents, CLAUDE.md — are exactly where all of this plugs in. I'm not replacing the loop. I'm giving it a substrate.
+
+The model was never the bottleneck, and neither is the loop. The substrate is — tokens, memory, independent verification. Build the loop. Then give it a stack.
+
+Full write-up, with the loop wired into the stack step by step:
+https://decebaldobrica.com/blog/2026-06-17-past-the-loop-claude-code-tooling-stack
+
+---
+
+## Option B — Short opener (if you'd rather lead a thread or keep it tight, ~270 words)
+
+Best Claude Code thread I've read in a while — and still only half the story.
+
+Your point stands: the difference is the loop, not the model. But a loop is just control flow. It assumes three things that are false on a real codebase:
+
+• Context is free — explore+plan+build+test+review+rereview is 6+ passes per task. Token bonfire.
+• Memory persists — plan mode + CLAUDE.md die at /compact. Tomorrow the agent re-explores the same code.
+• An in-session reviewer is independent — same model, same session, same blind spots, your token budget.
+
+The loop is the floor. The stack underneath is what makes it run:
+
+— caveman + rtk: cut output and terminal tokens so the loop stays affordable
+— chronis: event-sourced task CLI, the plan becomes a replayable graph that outlives the session (TOON output = ~50% fewer tokens) + AllSource Prime for cross-session memory (both mine — disclosing)
+— CodeRabbit: independent review on the PR, outside your context
+— pixel-perfect overlay: the missing step — tests and LLM review never look at the rendered pixels
+
+The model was never the bottleneck, and neither is the loop. The substrate is.
+
+Full write-up: https://decebaldobrica.com/blog/2026-06-17-past-the-loop-claude-code-tooling-stack
+
+---
+
+### Notes
+- No hashtags (your playbook: social = relationship, not keyword stuffing).
+- Canonical link points back to the blog per "one canonical home, many syndication surfaces."
+- If posting as a reply: post Option A directly under 0xMorty's tweet. If you want reach beyond his followers, quote-tweet instead with the first 2 lines as the hook.
+- Verify the live URL resolves before posting.

--- a/apps/wolventech/src/app/contact/page.tsx
+++ b/apps/wolventech/src/app/contact/page.tsx
@@ -26,6 +26,7 @@ export default function ContactPage() {
         enablePayments={false}
         theme="rust"
         chatConfig={{ enabled: false }}
+        backHref="/#services"
       />
     </Suspense>
   )

--- a/packages/booking/src/ContactBookingPage.tsx
+++ b/packages/booking/src/ContactBookingPage.tsx
@@ -113,6 +113,12 @@ export interface ContactBookingPageProps {
   referralCategoryDefault?: string
   className?: string
   /**
+   * Where the post-booking "Back to Services" button links. Apps with a
+   * dedicated route use `/services` (default); single-page sites pass an
+   * anchor like `/#services`.
+   */
+  backHref?: string
+  /**
    * Slot rendered at the bottom of the page. Each app supplies its own
    * branded Footer component so the package stays visually app-agnostic.
    */
@@ -127,6 +133,7 @@ export default function ContactBookingPage({
   referralCategoryDefault,
   className,
   footer,
+  backHref = '/services',
 }: ContactBookingPageProps) {
   const searchParams = useSearchParams()
   const urlCategory = searchParams.get('category') || referralCategoryDefault || undefined
@@ -508,7 +515,7 @@ export default function ContactBookingPage({
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.8, duration: 0.5 }}
               >
-                <Link href="/services">
+                <Link href={backHref}>
                   <Button variant="outline" className="w-full sm:w-auto">
                     <ArrowLeft className="mr-2 h-4 w-4" />
                     Back to Services
@@ -520,28 +527,30 @@ export default function ContactBookingPage({
               </motion.div>
             </motion.div>
 
-            {/* Scroll Indicator on Success Page - Matches hero section style */}
-            <motion.div
-              className="flex justify-center mt-16 mb-8"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ delay: 1, duration: 0.8 }}
-            >
-              <div className="animate-bounce">
-                <button
-                  type="button"
-                  onClick={() => {
-                    const chatSection = document.querySelector('[data-success-chat-section]')
-                    if (chatSection) {
-                      chatSection.scrollIntoView({ behavior: 'smooth' })
-                    }
-                  }}
-                  className="bg-white/10 backdrop-blur-sm p-3 rounded-full shadow-md hover:bg-white/20 transition-colors"
-                >
-                  <ChevronDown className="text-brand-teal" />
-                </button>
-              </div>
-            </motion.div>
+            {/* Scroll Indicator on Success Page - only when chat is below */}
+            {chatConfig?.enabled !== false && (
+              <motion.div
+                className="flex justify-center mt-16 mb-8"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ delay: 1, duration: 0.8 }}
+              >
+                <div className="animate-bounce">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const chatSection = document.querySelector('[data-success-chat-section]')
+                      if (chatSection) {
+                        chatSection.scrollIntoView({ behavior: 'smooth' })
+                      }
+                    }}
+                    className="bg-white/10 backdrop-blur-sm p-3 rounded-full shadow-md hover:bg-white/20 transition-colors"
+                  >
+                    <ChevronDown className="text-brand-teal" />
+                  </button>
+                </div>
+              </motion.div>
+            )}
 
             {/* Chat Section on Success Page */}
             {chatConfig?.enabled !== false && (
@@ -997,30 +1006,32 @@ export default function ContactBookingPage({
           </div>
         </div>
 
-        {/* Scroll Indicator - Matches hero section style */}
-        <div className="px-4 md:px-8 py-20 md:py-32 max-w-7xl mx-auto">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ delay: 1, duration: 0.8 }}
-            className="max-w-4xl mx-auto flex justify-center"
-          >
-            <div className="animate-bounce">
-              <button
-                type="button"
-                onClick={() => {
-                  const chatSection = document.querySelector('[data-chat-section]')
-                  if (chatSection) {
-                    chatSection.scrollIntoView({ behavior: 'smooth' })
-                  }
-                }}
-                className="bg-white/10 backdrop-blur-sm p-3 rounded-full shadow-md hover:bg-white/20 transition-colors"
-              >
-                <ChevronDown className="text-brand-teal" />
-              </button>
-            </div>
-          </motion.div>
-        </div>
+        {/* Scroll Indicator - only when there's a chat section below to reach */}
+        {chatConfig?.enabled !== false && (
+          <div className="px-4 md:px-8 py-20 md:py-32 max-w-7xl mx-auto">
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 1, duration: 0.8 }}
+              className="max-w-4xl mx-auto flex justify-center"
+            >
+              <div className="animate-bounce">
+                <button
+                  type="button"
+                  onClick={() => {
+                    const chatSection = document.querySelector('[data-chat-section]')
+                    if (chatSection) {
+                      chatSection.scrollIntoView({ behavior: 'smooth' })
+                    }
+                  }}
+                  className="bg-white/10 backdrop-blur-sm p-3 rounded-full shadow-md hover:bg-white/20 transition-colors"
+                >
+                  <ChevronDown className="text-brand-teal" />
+                </button>
+              </div>
+            </motion.div>
+          </div>
+        )}
 
         {/* Chat Section - Well Below the Fold */}
         {chatConfig?.enabled !== false && (


### PR DESCRIPTION
## Problems (wolventech /contact)
1. **"Back to Services" → 404.** The shared `ContactBookingPage` hardcoded `href="/services"`, but wolventech is single-page (`/#services` anchors, no `/services` route).
2. **Orphan scroll chevron.** A bouncing down-chevron showed even with chat disabled — it scrolls to the AI chat section, which is hidden, so it pointed at nothing.

## Fix
- Add a `backHref` prop to `ContactBookingPage` (default `/services` — web app unchanged). wolventech passes `backHref="/#services"`.
- Gate both scroll-down chevrons (form view + success view) on `chatConfig.enabled !== false`, matching the already-gated chat section.

## Verified
Biome clean; `wolventech build` ✓ compiled, 8/8 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)