### PR TITLE
fix: blog terminal code blocks rendering [object Object]

### DIFF
--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -1,7 +1,13 @@
 import { BlogCTA } from '@/components/BlogCTA'
 import { BlogTOC } from '@/components/BlogTOC'
 import Footer from '@/components/Footer'
-import { Terminal, TerminalCommand, TerminalLine, TerminalOutput } from '@/components/blog/Terminal'
+import {
+  Terminal,
+  TerminalCommand,
+  TerminalLine,
+  TerminalOutput,
+} from '@/components/blog/Terminal'
+import { extractText } from '@/components/blog/extractText'
 import { getAllBlogPosts, getBlogPost } from '@/lib/blogPosts'
 import { formatDate } from '@/lib/blogPosts'
 import { Badge } from '@decebal/ui/badge'
@@ -189,8 +195,10 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                           className?.includes('language-console')
 
                         if (isTerminal) {
-                          // Parse terminal content
-                          const content = String(children).trim()
+                          // Parse terminal content. rehype-highlight turns the
+                          // code body into token elements, so String(children)
+                          // would yield "[object Object]" — extract the text.
+                          const content = extractText(children).trim()
                           const lines = content.split('\n')
 
                           // Extract title from first line if it's a comment

--- a/apps/web/src/components/blog/Terminal.tsx
+++ b/apps/web/src/components/blog/Terminal.tsx
@@ -2,6 +2,7 @@
 
 import { Check, Copy, Maximize2, Minimize2, Terminal as TerminalIcon } from 'lucide-react'
 import { useState } from 'react'
+import { extractText } from './extractText'
 
 interface TerminalProps {
   children: React.ReactNode
@@ -195,25 +196,6 @@ export function TerminalLine({
       {children}
     </div>
   )
-}
-
-/**
- * Helper to extract text from React nodes
- */
-function extractText(node: React.ReactNode): string {
-  if (typeof node === 'string' || typeof node === 'number') {
-    return String(node)
-  }
-
-  if (Array.isArray(node)) {
-    return node.map(extractText).join('')
-  }
-
-  if (node && typeof node === 'object' && 'props' in node) {
-    return extractText(node.props.children)
-  }
-
-  return ''
 }
 
 /**

--- a/apps/web/src/components/blog/extractText.ts
+++ b/apps/web/src/components/blog/extractText.ts
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Recursively extract the plain text from a React node tree.
+ *
+ * Used to recover raw code from a fenced block after rehype-highlight has
+ * turned the body into nested token elements (where `String(children)` would
+ * yield "[object Object]"). Lives in a server-safe module so it can be called
+ * from both server components (the blog renderer) and client components.
+ */
+export function extractText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(extractText).join('')
+  }
+
+  if (node && typeof node === 'object' && 'props' in node) {
+    return extractText((node.props as { children?: ReactNode }).children)
+  }
+
+  return ''
+}


### PR DESCRIPTION
## Problem
Fenced `bash`/`shell`/`terminal`/`console` code blocks in blog posts rendered as repeated **`[object Object]`** (e.g. the "past the loop" post's `cn task create ...` block).

## Root cause
The blog renderer parsed the terminal body with `String(children)`. But `rehype-highlight` transforms the code body into nested token (`<span>`) elements, so `String([...elements])` yields `"[object Object],[object Object],…"`.

## Fix
Extract the raw text recursively (`extractText`) instead of `String()`. Moved `extractText` into a **server-safe** module (`extractText.ts`) — the blog page is a server component, and importing the helper from the `'use client'` `Terminal.tsx` module broke the build (`Attempted to call extractText() from the server...`). `Terminal.tsx` now imports the shared util too.

## Verified
Full `apps/web` build: 193/193 pages prerendered, no errors. Prerendered HTML for the post has **0** `[object Object]` and shows real commands (`cn task create "Add rate limiting" -p p0 --type=epic`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)