### PR TITLE
feat: full-bleed canvas-like radar hero with pan/zoom, quadrant focus, ⌘K search

### DIFF
--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { BlogCTA } from '@/components/BlogCTA'
 import { BlogTOC } from '@/components/BlogTOC'
 import Footer from '@/components/Footer'
+import { RadarBanner, shouldShowRadarBanner } from '@/components/RadarBanner'
 import {
   Terminal,
   TerminalCommand,
@@ -65,6 +66,8 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     notFound()
   }
 
+  const showRadar = shouldShowRadarBanner(post.tags)
+
   return (
     <div className="min-h-screen relative">
       <main className="pt-24 pb-16">
@@ -116,6 +119,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                   ))}
                 </div>
               )}
+
+              {/* Radar promo — slim strip (Rust/AI posts only) */}
+              {showRadar && <RadarBanner variant="strip" />}
 
               {/* Archive Notice for Imported Posts */}
               {post.canonicalUrl && (
@@ -324,6 +330,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                   </ReactMarkdown>
                 </div>
               </div>
+
+              {/* Radar promo — compact card above the connect CTA (Rust/AI posts only) */}
+              {showRadar && <RadarBanner variant="card" />}
 
               {/* Call to Action */}
               <BlogCTA postTitle={post.title} />

--- a/apps/web/src/app/radar/page.tsx
+++ b/apps/web/src/app/radar/page.tsx
@@ -1,0 +1,29 @@
+import CrateRadar from '@/components/CrateRadar'
+import Footer from '@/components/Footer'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Rust & AI Crate Radar',
+  description:
+    'A living Tech Radar of the Rust + AI ecosystem — agent SDKs, inference engines, vector/RAG crates, and dev tooling — each vetted for maintenance and adoption and placed by an Adopt / Trial / Assess / Hold verdict. Updated as new issues of the Rust Systems & Agentic AI newsletter ship.',
+  openGraph: {
+    title: 'Rust & AI Crate Radar',
+    description:
+      'A living Tech Radar of the Rust + AI ecosystem, vetted for maintenance and adoption. Adopt / Trial / Assess / Hold.',
+    type: 'website',
+  },
+}
+
+export default function RadarPage() {
+  return (
+    <div className="relative min-h-screen">
+      {/* Full-bleed: the radar breaks out of `section-container` and owns the
+          viewport below the fixed navbar (pt-20 ≈ navbar height). The hero sets
+          its own height of calc(100svh - 5rem); the footer follows on scroll. */}
+      <main className="pt-20">
+        <CrateRadar />
+      </main>
+      <Footer />
+    </div>
+  )
+}

--- a/apps/web/src/components/CrateRadar.tsx
+++ b/apps/web/src/components/CrateRadar.tsx
@@ -1,0 +1,4 @@
+// The Crate Radar was redesigned into a full-bleed, interactive hero. The
+// implementation now lives in `components/radar/`; this stays as a thin
+// re-export so existing imports (and the /radar page) keep working.
+export { default } from './radar/RadarHero'

--- a/apps/web/src/components/RadarBanner.tsx
+++ b/apps/web/src/components/RadarBanner.tsx
@@ -1,0 +1,93 @@
+import { RADAR_RINGS, crateRadarTools } from '@/data/crateRadar'
+import { Button } from '@decebal/ui/button'
+import { ArrowRight, Radar } from 'lucide-react'
+import Link from 'next/link'
+
+// Tags that make a post relevant to the Rust & AI Crate Radar. A post showing
+// any of these gets the banner; everything else (personal/older posts) stays clean.
+const RADAR_TAGS = new Set(['rust', 'crates', 'crate-radar', 'ai', 'llm', 'agents', 'inference'])
+
+export function shouldShowRadarBanner(tags?: string[]): boolean {
+  if (!tags?.length) return false
+  return tags.some((t) => RADAR_TAGS.has(t.toLowerCase()))
+}
+
+// Ring accent colors mirror the radar itself (traffic-light verdict semantics).
+const RING_DOT: Record<string, string> = {
+  Adopt: '#3fb950',
+  Trial: '#58a6ff',
+  Assess: '#d29922',
+  Hold: '#f85149',
+}
+
+const TOOL_COUNT = crateRadarTools.length
+
+function RingDots() {
+  return (
+    <span className="inline-flex items-center gap-1" aria-hidden="true">
+      {RADAR_RINGS.map((ring) => (
+        <span
+          key={ring}
+          className="h-1.5 w-1.5 rounded-full"
+          style={{ background: RING_DOT[ring] }}
+        />
+      ))}
+    </span>
+  )
+}
+
+interface RadarBannerProps {
+  /** `strip` = slim one-liner (top of post); `card` = compact CTA card (bottom). */
+  variant?: 'strip' | 'card'
+}
+
+export function RadarBanner({ variant = 'card' }: RadarBannerProps) {
+  if (variant === 'strip') {
+    return (
+      <Link
+        href="/radar"
+        className="group mb-8 flex items-center gap-3 rounded-lg border border-brand-teal/30 bg-white/5 px-4 py-2.5 backdrop-blur-sm transition-colors hover:border-brand-teal/60 hover:bg-brand-teal/10"
+      >
+        <Radar className="h-4 w-4 shrink-0 text-brand-teal" aria-hidden="true" />
+        <span className="text-sm text-gray-300">
+          <span className="font-semibold text-white">Rust &amp; AI Crate Radar</span>
+          <span className="hidden sm:inline">
+            {' '}
+            — {TOOL_COUNT} tools mapped by Adopt / Trial / Assess / Hold
+          </span>
+        </span>
+        <span className="ml-auto inline-flex shrink-0 items-center gap-1 text-sm font-medium text-brand-teal">
+          Explore
+          <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+        </span>
+      </Link>
+    )
+  }
+
+  return (
+    <div className="mt-12 flex flex-col gap-4 rounded-xl border border-brand-teal/30 bg-white/5 p-5 backdrop-blur-sm sm:flex-row sm:items-center">
+      {/* Radar glyph */}
+      <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-brand-teal/40 bg-brand-teal/10">
+        <Radar className="h-6 w-6 text-brand-teal" aria-hidden="true" />
+      </div>
+
+      {/* Copy */}
+      <div className="flex-1">
+        <h3 className="text-lg font-bold text-white">Rust &amp; AI Crate Radar</h3>
+        <p className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-gray-300">
+          Every tool I feature, mapped by verdict
+          <RingDots />
+          <span className="text-gray-400">· {TOOL_COUNT} tools</span>
+        </p>
+      </div>
+
+      {/* CTA */}
+      <Link href="/radar" className="shrink-0">
+        <Button className="bg-brand-teal text-white hover:bg-brand-teal/80">
+          Explore the radar
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      </Link>
+    </div>
+  )
+}

--- a/apps/web/src/components/radar/RadarBackdrop.tsx
+++ b/apps/web/src/components/radar/RadarBackdrop.tsx
@@ -1,0 +1,43 @@
+// Ambient, non-interactive backdrop for the radar hero.
+//
+// Hybrid-render strategy: this is the CSS/canvas-style layer that gives the
+// surface its "canvas" feel (glow, faint grid texture, vignette). It is FIXED
+// behind the SVG and deliberately does NOT track the pan/zoom transform, which
+// sidesteps the two-layers-out-of-sync trap entirely. The interactive blips
+// live in the SVG above and stay focusable DOM nodes.
+
+const gridStyle: React.CSSProperties = {
+  backgroundImage:
+    'linear-gradient(to right, rgba(148,163,184,0.06) 1px, transparent 1px),' +
+    'linear-gradient(to bottom, rgba(148,163,184,0.06) 1px, transparent 1px)',
+  backgroundSize: '44px 44px',
+  maskImage: 'radial-gradient(ellipse 75% 75% at 50% 45%, black 30%, transparent 78%)',
+  WebkitMaskImage: 'radial-gradient(ellipse 75% 75% at 50% 45%, black 30%, transparent 78%)',
+}
+
+export default function RadarBackdrop() {
+  return (
+    <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">
+      {/* base wash */}
+      <div className="absolute inset-0 bg-slate-950" />
+      {/* central glow — the "energy" under the radar */}
+      <div
+        className="absolute left-1/2 top-[44%] h-[80vmin] w-[80vmin] -translate-x-1/2 -translate-y-1/2 rounded-full opacity-70 blur-3xl"
+        style={{
+          background:
+            'radial-gradient(circle, rgba(56,189,248,0.18) 0%, rgba(16,185,129,0.10) 38%, transparent 70%)',
+        }}
+      />
+      {/* faint grid texture */}
+      <div className="absolute inset-0" style={gridStyle} />
+      {/* vignette to focus the eye on the centre */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(ellipse 95% 90% at 50% 45%, transparent 55%, rgba(2,6,23,0.85) 100%)',
+        }}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/radar/RadarCanvas.tsx
+++ b/apps/web/src/components/radar/RadarCanvas.tsx
@@ -1,0 +1,371 @@
+'use client'
+
+import { RADAR_QUADRANTS, RADAR_RINGS } from '@/data/crateRadar'
+import type { RadarQuadrant } from '@/data/crateRadar'
+import { cn } from '@/lib/utils'
+import { useCallback, useRef } from 'react'
+import {
+  BOUNDS,
+  type Blip,
+  CENTER,
+  DRAG_THRESHOLD,
+  OUTER,
+  RING_COLORS,
+  type Transform,
+  VIEW,
+  VIEW_MIN,
+  ringMidRadius,
+  transformStyle,
+} from './geometry'
+import type { useRadarTransform } from './useRadarTransform'
+
+type RadarTransformApi = ReturnType<typeof useRadarTransform>
+
+interface RadarCanvasProps {
+  blips: Blip[]
+  transform: Transform
+  api: RadarTransformApi
+  isVisible: (b: Blip) => boolean
+  focusedQuadrant: RadarQuadrant | null
+  hiddenQuads: Set<RadarQuadrant>
+  focusNum: number | null
+  selectedNum: number | null
+  reducedMotion: boolean
+  onHoverBlip: (n: number | null) => void
+  onSelectBlip: (n: number) => void
+  onFocusQuadrant: (q: RadarQuadrant) => void
+  onBackgroundClick: () => void
+  registerBlipRef: (n: number, el: SVGGElement | null) => void
+}
+
+const cssVars = `
+.radar-blip:focus-visible { outline: none }
+.radar-blip:focus-visible .radar-shape { stroke: #38bdf8; stroke-width: 3 }
+.radar-blip-anim { transition: opacity .35s ease, transform .35s cubic-bezier(.22,1,.36,1) }
+.radar-blip-anim .radar-shape,
+.radar-blip-anim text { transform-box: fill-box; transform-origin: center }
+.radar-reduced .radar-blip-anim { transition: none }
+`
+
+export default function RadarCanvas({
+  blips,
+  transform,
+  api,
+  isVisible,
+  focusedQuadrant,
+  hiddenQuads,
+  focusNum,
+  selectedNum,
+  reducedMotion,
+  onHoverBlip,
+  onSelectBlip,
+  onFocusQuadrant,
+  onBackgroundClick,
+  registerBlipRef,
+}: RadarCanvasProps) {
+  // Pointer drag tracking — distinguishes pan from click via DRAG_THRESHOLD.
+  const dragState = useRef<{
+    pointerId: number
+    startX: number
+    startY: number
+    lastX: number
+    lastY: number
+    moved: boolean
+  } | null>(null)
+
+  const onPointerDown = useCallback((e: React.PointerEvent<SVGSVGElement>) => {
+    // Ignore secondary buttons; let blips/controls keep their own handlers.
+    if (e.button !== 0) return
+    dragState.current = {
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      lastX: e.clientX,
+      lastY: e.clientY,
+      moved: false,
+    }
+  }, [])
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      const d = dragState.current
+      if (!d || d.pointerId !== e.pointerId) return
+      const totalDx = e.clientX - d.startX
+      const totalDy = e.clientY - d.startY
+      if (!d.moved && Math.hypot(totalDx, totalDy) < DRAG_THRESHOLD) return
+      if (!d.moved) {
+        d.moved = true
+        e.currentTarget.setPointerCapture(e.pointerId)
+      }
+      api.panByPixels(e.clientX - d.lastX, e.clientY - d.lastY)
+      d.lastX = e.clientX
+      d.lastY = e.clientY
+    },
+    [api]
+  )
+
+  const endDrag = useCallback((e: React.PointerEvent<SVGSVGElement>) => {
+    const d = dragState.current
+    if (!d || d.pointerId !== e.pointerId) return
+    if (d.moved && e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
+    dragState.current = null
+  }, [])
+
+  // Was the just-finished interaction a drag (suppress click) or a tap (allow)?
+  const consumedDrag = useRef(false)
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      consumedDrag.current = dragState.current?.moved ?? false
+      endDrag(e)
+    },
+    [endDrag]
+  )
+
+  const onWheel = useCallback(
+    (e: React.WheelEvent<SVGSVGElement>) => {
+      e.preventDefault()
+      const anchor = api.toUserSpace(e.clientX, e.clientY)
+      // Trackpad pinch arrives as wheel+ctrlKey; normalise both to a factor.
+      const factor = Math.exp(-e.deltaY * 0.0015)
+      api.zoomAt(factor, anchor)
+    },
+    [api]
+  )
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<SVGSVGElement>) => {
+      if (e.key === '+' || e.key === '=') {
+        e.preventDefault()
+        api.zoomBy(1.25)
+      } else if (e.key === '-' || e.key === '_') {
+        e.preventDefault()
+        api.zoomBy(0.8)
+      } else if (e.key === '0') {
+        e.preventDefault()
+        api.reset()
+      }
+    },
+    [api]
+  )
+
+  const handleBackgroundClick = useCallback(() => {
+    if (consumedDrag.current) {
+      consumedDrag.current = false
+      return
+    }
+    onBackgroundClick()
+  }, [onBackgroundClick])
+
+  const quadLabelPos: Record<RadarQuadrant, [number, number, 'start' | 'end']> = {
+    agentic: [CENTER - OUTER, CENTER - OUTER - 14, 'start'],
+    inference: [CENTER + OUTER, CENTER - OUTER - 14, 'end'],
+    data: [CENTER - OUTER, CENTER + OUTER + 24, 'start'],
+    dev: [CENTER + OUTER, CENTER + OUTER + 24, 'end'],
+  }
+
+  const viewBox = `${VIEW_MIN} ${VIEW_MIN} ${VIEW} ${VIEW}`
+
+  return (
+    <svg
+      ref={api.svgRef}
+      viewBox={viewBox}
+      className={cn(
+        'absolute inset-0 h-full w-full touch-none select-none',
+        dragState.current?.moved ? 'cursor-grabbing' : 'cursor-grab',
+        reducedMotion && 'radar-reduced'
+      )}
+      role="application"
+      aria-label="Rust and AI crate radar — pan, zoom, and select tools. Blips sized by adoption."
+      aria-roledescription="Interactive radar"
+      // biome-ignore lint/a11y/noNoninteractiveTabindex: intentional keyboard-operable application surface (role="application") for pan/zoom — focusability is required.
+      tabIndex={0}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={endDrag}
+      onWheel={onWheel}
+      onKeyDown={onKeyDown}
+    >
+      <title>Rust &amp; AI Crate Radar</title>
+      <style>{cssVars}</style>
+
+      {/* Transparent background catcher: a click here (no drag) clears focus.
+          The same action is keyboard-reachable via the global Esc handler and
+          the explicit close buttons, so this decorative catcher needs no key handler. */}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: decorative click-catcher; clearing focus is reachable via Esc and close buttons. */}
+      <rect
+        x={VIEW_MIN}
+        y={VIEW_MIN}
+        width={VIEW}
+        height={VIEW}
+        fill="transparent"
+        aria-hidden
+        onClick={handleBackgroundClick}
+      />
+
+      <g transform={transformStyle(transform)}>
+        {/* Rings */}
+        {[4, 3, 2, 1].map((i) => (
+          <g key={i}>
+            <circle
+              cx={CENTER}
+              cy={CENTER}
+              r={(BOUNDS[i] ?? 0) * CENTER}
+              fill={i % 2 ? 'rgba(255,255,255,0.025)' : 'transparent'}
+            />
+            <circle
+              cx={CENTER}
+              cy={CENTER}
+              r={(BOUNDS[i] ?? 0) * CENTER}
+              fill="none"
+              stroke="rgba(255,255,255,0.18)"
+            />
+          </g>
+        ))}
+
+        {/* Axes */}
+        <line
+          x1={CENTER}
+          y1={CENTER - OUTER}
+          x2={CENTER}
+          y2={CENTER + OUTER}
+          stroke="rgba(255,255,255,0.18)"
+        />
+        <line
+          x1={CENTER - OUTER}
+          y1={CENTER}
+          x2={CENTER + OUTER}
+          y2={CENTER}
+          stroke="rgba(255,255,255,0.18)"
+        />
+
+        {/* Ring labels */}
+        {RADAR_RINGS.map((ring, i) => (
+          <text
+            key={ring}
+            x={CENTER}
+            y={CENTER - ringMidRadius(i) + 4}
+            textAnchor="middle"
+            fontSize="11"
+            fontWeight={600}
+            fill="#94a3b8"
+            pointerEvents="none"
+          >
+            {ring}
+          </text>
+        ))}
+
+        {/* Quadrant labels (clickable to focus that quadrant) */}
+        {RADAR_QUADRANTS.map((q) => {
+          const [x, y, anchor] = quadLabelPos[q.key]
+          const dim = hiddenQuads.has(q.key)
+          const active = focusedQuadrant === q.key
+          return (
+            <text
+              key={q.key}
+              x={x}
+              y={y}
+              textAnchor={anchor}
+              fontSize="13"
+              fontWeight={700}
+              className="cursor-pointer focus:outline-none focus-visible:underline"
+              fill={dim ? '#64748b' : active ? '#7dd3fc' : '#e2e8f0'}
+              tabIndex={0}
+              // biome-ignore lint/a11y/useSemanticElements: an SVG <text> can't be a real <button>; role + tabIndex + aria-label + key handler is the accessible-SVG pattern.
+              role="button"
+              aria-label={`Focus ${q.label} quadrant`}
+              onClick={(e) => {
+                e.stopPropagation()
+                onFocusQuadrant(q.key)
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  onFocusQuadrant(q.key)
+                }
+              }}
+            >
+              {q.label}
+            </text>
+          )
+        })}
+
+        {/* Blips */}
+        {blips.map((b) => {
+          const vis = isVisible(b)
+          const isFocus = focusNum === b.number
+          const isSelected = selectedNum === b.number
+          const color = RING_COLORS[b.ring]
+          // Dim non-focused blips when a quadrant is in focus, or when a single blip is focused.
+          const quadDim = focusedQuadrant != null && b.quadrant !== focusedQuadrant
+          const otherFocusDim = focusNum != null && !isFocus
+          const opacity = !vis ? 0.08 : quadDim ? 0.22 : otherFocusDim ? 0.4 : 1
+          const labelEl = RADAR_QUADRANTS.find((q) => q.key === b.quadrant)?.label
+          return (
+            <g
+              key={b.number}
+              ref={(el) => registerBlipRef(b.number, el)}
+              className="radar-blip radar-blip-anim cursor-pointer"
+              tabIndex={vis ? 0 : -1}
+              // biome-ignore lint/a11y/useSemanticElements: an SVG <g> blip can't be a real <button>; role + tabIndex + aria-label + key handler is the accessible-SVG pattern.
+              role="button"
+              aria-label={`${b.name}, ${b.ring}, ${labelEl}${b.stars ? `, ${b.stars}` : ''}`}
+              aria-pressed={isSelected}
+              style={{ opacity, transform: vis ? undefined : 'scale(0.55)' }}
+              onMouseEnter={() => vis && onHoverBlip(b.number)}
+              onMouseLeave={() => onHoverBlip(null)}
+              onFocus={() => vis && onHoverBlip(b.number)}
+              onBlur={() => onHoverBlip(null)}
+              onClick={(e) => {
+                e.stopPropagation()
+                if (vis && !consumedDrag.current) onSelectBlip(b.number)
+                consumedDrag.current = false
+              }}
+              onKeyDown={(e) => {
+                if (vis && (e.key === 'Enter' || e.key === ' ')) {
+                  e.preventDefault()
+                  onSelectBlip(b.number)
+                }
+              }}
+            >
+              <title>{`${b.name} — ${b.ring}`}</title>
+              {b.returning ? (
+                <circle
+                  className="radar-shape"
+                  cx={b.x}
+                  cy={b.y}
+                  r={b.r}
+                  fill={color}
+                  stroke={isFocus ? '#fff' : 'none'}
+                  strokeWidth={isFocus ? 2.5 : 0}
+                />
+              ) : (
+                <polygon
+                  className="radar-shape"
+                  points={`${b.x},${b.y - b.r * 1.15} ${b.x - b.r * 1.1},${b.y + b.r * 0.85} ${b.x + b.r * 1.1},${b.y + b.r * 0.85}`}
+                  fill={color}
+                  stroke={isFocus ? '#fff' : 'none'}
+                  strokeWidth={isFocus ? 2.5 : 0}
+                />
+              )}
+              <text
+                x={b.x}
+                y={b.y + (b.returning ? 0 : 3)}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize={b.r > 11 ? 11 : 9}
+                fontWeight={700}
+                fill="#0b0b0b"
+                pointerEvents="none"
+              >
+                {b.number}
+              </text>
+            </g>
+          )
+        })}
+      </g>
+    </svg>
+  )
+}

--- a/apps/web/src/components/radar/RadarCommandPalette.tsx
+++ b/apps/web/src/components/radar/RadarCommandPalette.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { RADAR_QUADRANTS } from '@/data/crateRadar'
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@decebal/ui/command'
+import type { Blip } from './geometry'
+import { RING_COLORS } from './geometry'
+
+interface RadarCommandPaletteProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  blips: Blip[]
+  onSelect: (n: number) => void
+}
+
+export default function RadarCommandPalette({
+  open,
+  onOpenChange,
+  blips,
+  onSelect,
+}: RadarCommandPaletteProps) {
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange}>
+      <CommandInput placeholder="Search tools by name or category…" />
+      <CommandList>
+        <CommandEmpty>No tools found.</CommandEmpty>
+        {RADAR_QUADRANTS.map((q) => {
+          const items = blips.filter((b) => b.quadrant === q.key)
+          if (!items.length) return null
+          return (
+            <CommandGroup key={q.key} heading={q.label}>
+              {items.map((b) => (
+                <CommandItem
+                  key={b.number}
+                  // cmdk filters on this value — include name + category for fuzzy matching.
+                  value={`${b.name} ${b.category} ${b.ring}`}
+                  onSelect={() => onSelect(b.number)}
+                  className="gap-2"
+                >
+                  <span
+                    className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold text-black"
+                    style={{ background: RING_COLORS[b.ring] }}
+                  >
+                    {b.number}
+                  </span>
+                  <span className="font-medium text-foreground">{b.name}</span>
+                  <span className="ml-2 text-xs text-muted-foreground">{b.category}</span>
+                  <span
+                    className="ml-auto shrink-0 text-[10px] font-bold"
+                    style={{ color: RING_COLORS[b.ring] }}
+                  >
+                    {b.ring}
+                  </span>
+                  {(b.stars || b.downloads) && (
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      {b.stars || b.downloads}
+                    </span>
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )
+        })}
+      </CommandList>
+    </CommandDialog>
+  )
+}

--- a/apps/web/src/components/radar/RadarControls.tsx
+++ b/apps/web/src/components/radar/RadarControls.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { RADAR_GENERATED_AT, RADAR_QUADRANTS, RADAR_RINGS } from '@/data/crateRadar'
+import type { RadarQuadrant, RadarRing } from '@/data/crateRadar'
+import { cn } from '@/lib/utils'
+import { Minus, Plus, Scan, Search } from 'lucide-react'
+import type { Blip } from './geometry'
+import { RING_COLORS, RING_HELP } from './geometry'
+
+interface RadarControlsProps {
+  blips: Blip[]
+  shownCount: number
+  hiddenRings: Set<RadarRing>
+  hiddenQuads: Set<RadarQuadrant>
+  focusedQuadrant: RadarQuadrant | null
+  onToggleRing: (ring: RadarRing) => void
+  onToggleQuad: (quad: RadarQuadrant) => void
+  onFocusQuadrant: (quad: RadarQuadrant) => void
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onReset: () => void
+  onOpenPalette: () => void
+}
+
+const glass = 'rounded-2xl border border-white/10 bg-slate-950/85 backdrop-blur-md shadow-xl'
+
+export default function RadarControls({
+  blips,
+  shownCount,
+  hiddenRings,
+  hiddenQuads,
+  focusedQuadrant,
+  onToggleRing,
+  onToggleQuad,
+  onFocusQuadrant,
+  onZoomIn,
+  onZoomOut,
+  onReset,
+  onOpenPalette,
+}: RadarControlsProps) {
+  return (
+    <>
+      {/* Top-left: title, live count, filters, search trigger */}
+      <div
+        className={cn(
+          glass,
+          'pointer-events-auto absolute left-3 top-3 z-20 w-[min(92vw,26rem)] p-4 text-slate-200 md:left-5 md:top-5 md:p-5'
+        )}
+      >
+        <h1 className="text-xl font-bold tracking-tight text-slate-50 md:text-2xl">
+          Rust &amp; AI Crate Radar
+        </h1>
+        <p className="mt-1 hidden text-sm text-slate-300 sm:block">
+          A living map of every tool featured across the blog &amp; the{' '}
+          <span className="text-slate-100">Rust Systems &amp; Agentic AI</span> newsletter — placed
+          by quadrant and an Adopt / Trial / Assess / Hold verdict, sized by adoption.
+        </p>
+        <p className="mt-1.5 text-xs text-slate-400" aria-live="polite">
+          Showing {shownCount} of {blips.length} tools · snapshot {RADAR_GENERATED_AT}
+        </p>
+
+        {/* Search affordance — discoverable ⌘K trigger, usable on touch */}
+        <button
+          type="button"
+          onClick={onOpenPalette}
+          className="mt-3 flex w-full items-center gap-2 rounded-lg border border-white/15 bg-white/[0.04] px-3 py-2 text-left text-sm text-slate-400 transition hover:bg-white/[0.08] focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 motion-reduce:transition-none"
+        >
+          <Search className="h-4 w-4 shrink-0" aria-hidden />
+          <span className="flex-1">Search tools…</span>
+          <kbd className="hidden shrink-0 rounded border border-white/15 bg-white/10 px-1.5 py-0.5 font-mono text-[10px] text-slate-300 sm:inline">
+            ⌘K
+          </kbd>
+        </button>
+
+        {/* Ring filters */}
+        <div className="mt-3 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="mr-1 text-[11px] uppercase tracking-wide text-slate-500">Ring</span>
+            {RADAR_RINGS.map((ring) => {
+              const off = hiddenRings.has(ring)
+              const count = blips.filter((b) => b.ring === ring).length
+              return (
+                <button
+                  type="button"
+                  key={ring}
+                  aria-pressed={!off}
+                  title={RING_HELP[ring]}
+                  onClick={() => onToggleRing(ring)}
+                  className={cn(
+                    'inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 motion-reduce:transition-none',
+                    off
+                      ? 'border-white/10 text-slate-500 line-through'
+                      : 'border-white/20 text-slate-100 hover:bg-white/10'
+                  )}
+                >
+                  <span
+                    className="h-2.5 w-2.5 rounded-full"
+                    style={{ background: RING_COLORS[ring] }}
+                  />
+                  {ring} <span className="text-slate-400">({count})</span>
+                </button>
+              )
+            })}
+          </div>
+          {/* Area filters (toggle visibility); double as quadrant focus shortcut */}
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="mr-1 text-[11px] uppercase tracking-wide text-slate-500">Area</span>
+            {RADAR_QUADRANTS.map((q) => {
+              const off = hiddenQuads.has(q.key)
+              const active = focusedQuadrant === q.key
+              return (
+                <button
+                  type="button"
+                  key={q.key}
+                  aria-pressed={!off}
+                  onClick={() => onToggleQuad(q.key)}
+                  onDoubleClick={() => !off && onFocusQuadrant(q.key)}
+                  title={`Toggle ${q.label}. Double-click to zoom in.`}
+                  className={cn(
+                    'rounded-full border px-3 py-1 text-xs font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 motion-reduce:transition-none',
+                    off
+                      ? 'border-white/10 text-slate-500 line-through'
+                      : active
+                        ? 'border-sky-400/60 bg-sky-500/15 text-sky-100'
+                        : 'border-white/20 text-slate-100 hover:bg-white/10'
+                  )}
+                >
+                  {q.label}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Persistent legend — verdict reads in greyscale (radial band + shape). */}
+        <p className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] leading-snug text-slate-400">
+          <span aria-hidden className="text-slate-300">
+            ▲
+          </span>
+          new this cycle
+          <span aria-hidden className="ml-1 text-slate-300">
+            ●
+          </span>
+          featured before · size ≈ adoption
+        </p>
+      </div>
+
+      {/* Bottom-right: zoom + reset controls */}
+      <div
+        className={cn(
+          glass,
+          'pointer-events-auto absolute bottom-3 right-3 z-20 flex flex-col gap-1 p-1.5 md:bottom-5 md:right-5'
+        )}
+      >
+        <ControlButton label="Zoom in" onClick={onZoomIn}>
+          <Plus className="h-5 w-5" aria-hidden />
+        </ControlButton>
+        <ControlButton label="Zoom out" onClick={onZoomOut}>
+          <Minus className="h-5 w-5" aria-hidden />
+        </ControlButton>
+        <ControlButton label="Reset view" onClick={onReset}>
+          <Scan className="h-5 w-5" aria-hidden />
+        </ControlButton>
+      </div>
+    </>
+  )
+}
+
+function ControlButton({
+  label,
+  onClick,
+  children,
+}: {
+  label: string
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      className="flex h-10 w-10 items-center justify-center rounded-xl text-slate-200 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 motion-reduce:transition-none"
+    >
+      {children}
+    </button>
+  )
+}

--- a/apps/web/src/components/radar/RadarDetail.tsx
+++ b/apps/web/src/components/radar/RadarDetail.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { RADAR_QUADRANTS } from '@/data/crateRadar'
+import { cn } from '@/lib/utils'
+import { ExternalLink, X } from 'lucide-react'
+import type { Blip } from './geometry'
+import { RING_COLORS, RING_HELP } from './geometry'
+
+interface RadarDetailProps {
+  detail: Blip | null
+  isMobile: boolean
+  onClose: () => void
+}
+
+function DetailBody({ detail }: { detail: Blip }) {
+  const quadLabel = RADAR_QUADRANTS.find((q) => q.key === detail.quadrant)?.label
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-2">
+        <span
+          className="flex h-6 w-6 items-center justify-center rounded-full text-[11px] font-bold text-black"
+          style={{ background: RING_COLORS[detail.ring] }}
+        >
+          {detail.number}
+        </span>
+        <a
+          href={detail.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-lg font-bold text-slate-50 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70"
+        >
+          {detail.name}
+          <ExternalLink className="h-3.5 w-3.5 opacity-60" aria-hidden />
+        </a>
+        <span
+          className="rounded px-1.5 py-0.5 text-[10px] font-bold text-black"
+          style={{ background: RING_COLORS[detail.ring] }}
+        >
+          {detail.ring}
+        </span>
+        <span
+          className={cn(
+            'text-[10px] font-bold',
+            detail.returning ? 'text-slate-400' : 'text-emerald-400'
+          )}
+        >
+          {detail.returning ? '● returning' : '▲ new'}
+        </span>
+      </div>
+      <p className="mt-1 text-xs text-slate-400">
+        {RING_HELP[detail.ring]} · {detail.category}
+      </p>
+      <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+        <dt className="text-slate-500">Maintenance</dt>
+        <dd className="text-slate-200">{detail.maintenance}</dd>
+        <dt className="text-slate-500">Latest</dt>
+        <dd className="text-slate-200">{detail.latest}</dd>
+        <dt className="text-slate-500">Adoption</dt>
+        <dd className="text-slate-200">
+          {[detail.stars, detail.downloads].filter(Boolean).join(' · ') || '—'}
+        </dd>
+        {detail.adopters && (
+          <>
+            <dt className="text-slate-500">Users</dt>
+            <dd className="text-slate-200">{detail.adopters}</dd>
+          </>
+        )}
+        <dt className="text-slate-500">Seen in</dt>
+        <dd className="text-slate-300">{detail.mentions}</dd>
+      </dl>
+      {detail.note && <p className="mt-2 text-[11px] italic text-slate-400">{detail.note}</p>}
+      <p className="mt-3 text-[11px] text-slate-500">
+        Press <kbd className="rounded border border-white/15 px-1">Esc</kbd> to close · ▲ new · ●
+        returning · size ≈ adoption
+      </p>
+    </div>
+  )
+}
+
+export default function RadarDetail({ detail, isMobile, onClose }: RadarDetailProps) {
+  if (!detail) return null
+
+  if (isMobile) {
+    // Bottom sheet on small viewports.
+    return (
+      <div className="pointer-events-auto absolute inset-x-0 bottom-0 z-30 animate-in slide-in-from-bottom-4 duration-300 motion-reduce:animate-none">
+        <div className="rounded-t-2xl border-t border-white/10 bg-slate-950/95 p-4 text-slate-200 shadow-2xl backdrop-blur-md">
+          <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-white/20" aria-hidden />
+          <button
+            type="button"
+            aria-label="Close detail"
+            onClick={onClose}
+            className="absolute right-3 top-3 rounded-md p-1 text-slate-400 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </button>
+          <DetailBody detail={detail} />
+        </div>
+      </div>
+    )
+  }
+
+  // Floating glass card (desktop), top-right.
+  return (
+    <div className="pointer-events-auto absolute right-3 top-3 z-30 w-[min(90vw,22rem)] animate-in fade-in slide-in-from-right-2 duration-200 motion-reduce:animate-none md:right-5 md:top-5">
+      <div className="relative rounded-2xl border border-white/10 bg-slate-950/85 p-4 text-slate-200 shadow-xl backdrop-blur-md">
+        <button
+          type="button"
+          aria-label="Close detail"
+          onClick={onClose}
+          className="absolute right-3 top-3 rounded-md p-1 text-slate-400 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70"
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </button>
+        <DetailBody detail={detail} />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/radar/RadarHero.tsx
+++ b/apps/web/src/components/radar/RadarHero.tsx
@@ -1,0 +1,276 @@
+'use client'
+
+import { crateRadarTools } from '@/data/crateRadar'
+import type { RadarQuadrant, RadarRing } from '@/data/crateRadar'
+import { useIsMobile } from '@/hooks/use-mobile'
+import { cn } from '@/lib/utils'
+import { List } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import RadarBackdrop from './RadarBackdrop'
+import RadarCanvas from './RadarCanvas'
+import RadarCommandPalette from './RadarCommandPalette'
+import RadarControls from './RadarControls'
+import RadarDetail from './RadarDetail'
+import RadarList from './RadarList'
+import { type Blip, blipPoint, buildBlips, quadrantCentroid } from './geometry'
+import { useRadarTransform } from './useRadarTransform'
+import { useReducedMotion } from './useReducedMotion'
+
+// Zoom levels for programmatic focus moves.
+const QUADRANT_FOCUS_SCALE = 1.7
+const BLIP_FOCUS_SCALE = 2.1
+
+export default function RadarHero() {
+  const blips = useMemo(() => buildBlips(crateRadarTools), [])
+  const reducedMotion = useReducedMotion()
+  const isMobile = useIsMobile()
+  const api = useRadarTransform()
+
+  const [hiddenRings, setHiddenRings] = useState<Set<RadarRing>>(new Set())
+  const [hiddenQuads, setHiddenQuads] = useState<Set<RadarQuadrant>>(new Set())
+  const [selected, setSelected] = useState<number | null>(null)
+  const [hovered, setHovered] = useState<number | null>(null)
+  const [focusedQuadrant, setFocusedQuadrant] = useState<RadarQuadrant | null>(null)
+  const [paletteOpen, setPaletteOpen] = useState(false)
+  const [listOpen, setListOpen] = useState(false)
+
+  // DOM refs for blip <g> nodes so we can move focus to a programmatically-selected blip.
+  const blipRefs = useRef<Map<number, SVGGElement>>(new Map())
+  const registerBlipRef = useCallback((n: number, el: SVGGElement | null) => {
+    if (el) blipRefs.current.set(n, el)
+    else blipRefs.current.delete(n)
+  }, [])
+  // Restore focus to whatever opened the palette.
+  const restoreFocusRef = useRef<HTMLElement | null>(null)
+
+  const isVisible = useCallback(
+    (b: Blip) => !hiddenRings.has(b.ring) && !hiddenQuads.has(b.quadrant),
+    [hiddenRings, hiddenQuads]
+  )
+  const shownCount = useMemo(() => blips.filter(isVisible).length, [blips, isVisible])
+  const focusNum = hovered ?? selected
+  const detail = useMemo(() => blips.find((b) => b.number === focusNum) ?? null, [blips, focusNum])
+
+  const toggleRing = useCallback((ring: RadarRing) => {
+    setHiddenRings((cur) => {
+      const next = new Set(cur)
+      if (next.has(ring)) next.delete(ring)
+      else next.add(ring)
+      return next
+    })
+  }, [])
+
+  const toggleQuad = useCallback((quad: RadarQuadrant) => {
+    setHiddenQuads((cur) => {
+      const next = new Set(cur)
+      if (next.has(quad)) next.delete(quad)
+      else next.add(quad)
+      return next
+    })
+    // Hiding the focused quadrant drops focus.
+    setFocusedQuadrant((q) => (q === quad ? null : q))
+  }, [])
+
+  const focusQuadrant = useCallback(
+    (quad: RadarQuadrant) => {
+      setFocusedQuadrant((cur) => {
+        if (cur === quad) {
+          // Toggle off → back to full radar.
+          api.reset()
+          return null
+        }
+        api.focusPoint(quadrantCentroid(quad), QUADRANT_FOCUS_SCALE)
+        return quad
+      })
+    },
+    [api]
+  )
+
+  const selectBlip = useCallback(
+    (n: number, opts?: { center?: boolean; focusDom?: boolean }) => {
+      const b = blips.find((x) => x.number === n)
+      if (!b) return
+      setSelected((cur) => {
+        // Plain click on an already-selected blip toggles it off (matches old behavior).
+        if (cur === n && !opts?.center) return null
+        return n
+      })
+      if (opts?.center) {
+        api.focusPoint(blipPoint(b), BLIP_FOCUS_SCALE)
+      }
+      if (opts?.focusDom) {
+        // Defer until the node is mounted/visible.
+        requestAnimationFrame(() => blipRefs.current.get(n)?.focus())
+      }
+    },
+    [api, blips]
+  )
+
+  const clearSelection = useCallback(() => {
+    setSelected(null)
+    setHovered(null)
+  }, [])
+
+  const handleBackgroundClick = useCallback(() => {
+    if (focusedQuadrant) {
+      setFocusedQuadrant(null)
+      api.reset()
+    } else {
+      clearSelection()
+    }
+  }, [api, clearSelection, focusedQuadrant])
+
+  const openPalette = useCallback(() => {
+    restoreFocusRef.current = (document.activeElement as HTMLElement) ?? null
+    setPaletteOpen(true)
+  }, [])
+
+  const onPaletteSelect = useCallback(
+    (n: number) => {
+      setPaletteOpen(false)
+      selectBlip(n, { center: true, focusDom: true })
+    },
+    [selectBlip]
+  )
+
+  const onListSelect = useCallback(
+    (n: number) => {
+      selectBlip(n, { center: true, focusDom: true })
+      if (isMobile) setListOpen(false)
+    },
+    [isMobile, selectBlip]
+  )
+
+  // ⌘K / Ctrl+K to open the palette; Esc to step back out of focus/selection.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault()
+        openPalette()
+        return
+      }
+      if (e.key === 'Escape') {
+        // Let open dialogs handle their own Escape.
+        if (paletteOpen || listOpen) return
+        if (focusedQuadrant) {
+          setFocusedQuadrant(null)
+          api.reset()
+        } else if (selected != null) {
+          clearSelection()
+        }
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [api, clearSelection, focusedQuadrant, listOpen, openPalette, paletteOpen, selected])
+
+  // Restore focus when the palette closes (focus-trap restoration).
+  useEffect(() => {
+    if (!paletteOpen && restoreFocusRef.current) {
+      const el = restoreFocusRef.current
+      restoreFocusRef.current = null
+      // Only restore if we didn't intentionally move focus to a blip.
+      requestAnimationFrame(() => {
+        if (document.activeElement === document.body) el.focus?.()
+      })
+    }
+  }, [paletteOpen])
+
+  return (
+    <section
+      className="relative isolate w-full overflow-hidden bg-slate-950"
+      style={{ height: 'calc(100svh - 5rem)', minHeight: '34rem' }}
+      aria-label="Rust and AI Crate Radar interactive surface"
+    >
+      <RadarBackdrop />
+
+      <RadarCanvas
+        blips={blips}
+        transform={api.transform}
+        api={api}
+        isVisible={isVisible}
+        focusedQuadrant={focusedQuadrant}
+        hiddenQuads={hiddenQuads}
+        focusNum={focusNum}
+        selectedNum={selected}
+        reducedMotion={reducedMotion}
+        onHoverBlip={setHovered}
+        onSelectBlip={(n) => selectBlip(n)}
+        onFocusQuadrant={focusQuadrant}
+        onBackgroundClick={handleBackgroundClick}
+        registerBlipRef={registerBlipRef}
+      />
+
+      {/* Overlays sit above the canvas; the wrapper is click-through so the
+          canvas keeps receiving pan/zoom, while each panel re-enables pointers. */}
+      <div className="pointer-events-none absolute inset-0 z-10">
+        <RadarControls
+          blips={blips}
+          shownCount={shownCount}
+          hiddenRings={hiddenRings}
+          hiddenQuads={hiddenQuads}
+          focusedQuadrant={focusedQuadrant}
+          onToggleRing={toggleRing}
+          onToggleQuad={toggleQuad}
+          onFocusQuadrant={focusQuadrant}
+          onZoomIn={() => api.zoomBy(1.3)}
+          onZoomOut={() => api.zoomBy(0.77)}
+          onReset={() => {
+            setFocusedQuadrant(null)
+            api.reset()
+          }}
+          onOpenPalette={openPalette}
+        />
+
+        <RadarDetail detail={detail} isMobile={isMobile} onClose={clearSelection} />
+
+        {/* Browse-all trigger + "back to full radar" affordance */}
+        <div className="pointer-events-auto absolute bottom-3 left-3 z-20 flex items-center gap-2 md:bottom-5 md:left-5">
+          <button
+            type="button"
+            onClick={() => setListOpen(true)}
+            className="flex items-center gap-2 rounded-xl border border-white/10 bg-slate-950/85 px-3 py-2 text-sm font-semibold text-slate-200 shadow-xl backdrop-blur-md transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 motion-reduce:transition-none"
+          >
+            <List className="h-4 w-4" aria-hidden />
+            Browse all
+          </button>
+          {focusedQuadrant && (
+            <button
+              type="button"
+              onClick={() => {
+                setFocusedQuadrant(null)
+                api.reset()
+              }}
+              className="rounded-xl border border-sky-400/40 bg-sky-500/15 px-3 py-2 text-sm font-semibold text-sky-100 shadow-xl backdrop-blur-md transition hover:bg-sky-500/25 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 motion-reduce:transition-none"
+            >
+              ← Full radar
+            </button>
+          )}
+        </div>
+      </div>
+
+      <RadarList
+        open={listOpen}
+        onOpenChange={setListOpen}
+        blips={blips}
+        hiddenRings={hiddenRings}
+        hiddenQuads={hiddenQuads}
+        selectedNum={selected}
+        focusNum={focusNum}
+        onHover={setHovered}
+        onSelect={onListSelect}
+      />
+
+      <RadarCommandPalette
+        open={paletteOpen}
+        onOpenChange={setPaletteOpen}
+        blips={blips}
+        onSelect={onPaletteSelect}
+      />
+
+      <span className={cn('sr-only')} aria-live="polite">
+        {focusedQuadrant ? `Focused on ${focusedQuadrant} quadrant.` : 'Full radar view.'}
+      </span>
+    </section>
+  )
+}

--- a/apps/web/src/components/radar/RadarList.tsx
+++ b/apps/web/src/components/radar/RadarList.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { RADAR_QUADRANTS, RADAR_RINGS } from '@/data/crateRadar'
+import type { RadarQuadrant, RadarRing } from '@/data/crateRadar'
+import { cn } from '@/lib/utils'
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@decebal/ui/sheet'
+import type { Blip } from './geometry'
+import { RING_COLORS } from './geometry'
+
+interface RadarListProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  blips: Blip[]
+  hiddenRings: Set<RadarRing>
+  hiddenQuads: Set<RadarQuadrant>
+  selectedNum: number | null
+  focusNum: number | null
+  onHover: (n: number | null) => void
+  onSelect: (n: number) => void
+}
+
+export default function RadarList({
+  open,
+  onOpenChange,
+  blips,
+  hiddenRings,
+  hiddenQuads,
+  selectedNum,
+  focusNum,
+  onHover,
+  onSelect,
+}: RadarListProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="left"
+        className="w-[min(92vw,24rem)] border-white/10 bg-slate-950/95 text-slate-200 backdrop-blur-md sm:max-w-md"
+      >
+        <SheetHeader>
+          <SheetTitle className="text-slate-50">Browse all tools</SheetTitle>
+          <SheetDescription className="text-slate-400">
+            Respects your active filters. Selecting a tool centers it on the radar.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-4 max-h-[calc(100svh-8rem)] space-y-5 overflow-y-auto pr-1">
+          {RADAR_QUADRANTS.map((q) => {
+            if (hiddenQuads.has(q.key)) return null
+            const items = blips
+              .filter((b) => b.quadrant === q.key && !hiddenRings.has(b.ring))
+              .sort((a, c) => RADAR_RINGS.indexOf(a.ring) - RADAR_RINGS.indexOf(c.ring))
+            if (!items.length) return null
+            return (
+              <div key={q.key}>
+                <h2 className="mb-1.5 border-b border-white/10 pb-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  {q.label}
+                </h2>
+                <ul>
+                  {items.map((t) => (
+                    <li key={t.number}>
+                      <button
+                        type="button"
+                        onClick={() => onSelect(t.number)}
+                        onMouseEnter={() => onHover(t.number)}
+                        onMouseLeave={() => onHover(null)}
+                        onFocus={() => onHover(t.number)}
+                        onBlur={() => onHover(null)}
+                        className={cn(
+                          'flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70 motion-reduce:transition-none',
+                          selectedNum === t.number
+                            ? 'bg-sky-500/15'
+                            : focusNum === t.number
+                              ? 'bg-white/[0.08]'
+                              : 'hover:bg-white/[0.08]'
+                        )}
+                      >
+                        <span
+                          className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold text-black"
+                          style={{ background: RING_COLORS[t.ring] }}
+                        >
+                          {t.number}
+                        </span>
+                        <span className="truncate font-semibold text-slate-100">{t.name}</span>
+                        <span className="ml-auto shrink-0 text-[11px] text-slate-400">
+                          {t.stars || t.downloads || ''}
+                        </span>
+                        <span
+                          className="shrink-0 text-[10px] font-bold"
+                          style={{ color: RING_COLORS[t.ring] }}
+                        >
+                          {t.ring}
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )
+          })}
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/web/src/components/radar/geometry.ts
+++ b/apps/web/src/components/radar/geometry.ts
@@ -1,0 +1,197 @@
+// Geometry + transform helpers for the Rust & AI Crate Radar.
+//
+// Pure, framework-free, and unit-testable. The redesign keeps the *exact*
+// blip placement math the original SVG used (`buildBlips`), and adds the
+// pan/zoom/quadrant-focus transform helpers that the full-bleed hero drives
+// from a single `{ x, y, scale }` state. The `RadarTool` data contract in
+// `@/data/crateRadar` is untouched.
+
+import { RADAR_QUADRANTS, RADAR_RINGS } from '@/data/crateRadar'
+import type { RadarQuadrant, RadarRing, RadarTool } from '@/data/crateRadar'
+
+// Accent palette (GitHub dark-mode accessible set). Traffic-light semantics:
+// green = safe to adopt … red = hold/caution. The verdict is *also* encoded by
+// radial band + blip shape, so it stays legible in greyscale.
+export const RING_COLORS: Record<RadarRing, string> = {
+  Adopt: '#3fb950',
+  Trial: '#58a6ff',
+  Assess: '#d29922',
+  Hold: '#f85149',
+}
+
+export const RING_HELP: Record<RadarRing, string> = {
+  Adopt: 'Proven — safe to standardize on',
+  Trial: 'Worth using on real work, eyes open',
+  Assess: 'Promising — explore before betting',
+  Hold: 'Proceed with caution / don’t newly depend',
+}
+
+// Screen-space angle ranges (deg, y-down): agentic=TL, inference=TR, data=BL, dev=BR.
+export const QUAD_ANGLE: Record<RadarQuadrant, [number, number]> = {
+  agentic: [180, 270],
+  inference: [270, 360],
+  data: [90, 180],
+  dev: [0, 90],
+}
+
+// Intrinsic SVG geometry. The rendered size is driven by the container; these
+// are the coordinates the blips live in. Keep them stable — they are the
+// source of truth the transform group multiplies over.
+export const R = 300
+export const PAD = 52
+// Ring boundaries (fraction of R), inner→outer.
+export const BOUNDS = [0, 0.42, 0.6, 0.78, 0.95] as const
+export const A_PAD = 11 // degrees of breathing room from each quadrant edge
+
+export const VIEW = 2 * R + 2 * PAD // full viewBox extent (width == height)
+// viewBox is `-PAD -PAD VIEW VIEW`, so content coordinates are NOT PAD-offset:
+// the radar center stays at (R, R) and the visible window simply starts at -PAD.
+export const VIEW_MIN = -PAD
+export const CENTER = R // center of the radar, in viewBox user-space
+export const OUTER = BOUNDS[4] * R
+
+export interface Blip extends RadarTool {
+  number: number
+  x: number
+  y: number
+  r: number
+  weight: number
+}
+
+export interface Transform {
+  x: number
+  y: number
+  scale: number
+}
+
+export const IDENTITY: Transform = { x: 0, y: 0, scale: 1 }
+
+export const MIN_SCALE = 0.6
+export const MAX_SCALE = 4
+
+export function clampScale(scale: number): number {
+  return Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale))
+}
+
+export function magnitude(s?: string): number {
+  if (!s) return 0
+  const m = String(s).match(/([\d.]+)\s*([kKmM])?/)
+  if (!m || m[1] === undefined) return 0
+  let v = Number.parseFloat(m[1])
+  const u = (m[2] || '').toLowerCase()
+  if (u === 'k') v *= 1e3
+  if (u === 'm') v *= 1e6
+  return v
+}
+
+// Hierarchy: bigger blip = more adopted. log-scaled so 13M doesn't dwarf 600★.
+export function radiusFor(weight: number): number {
+  if (!weight) return 8.5
+  const r = 8 + (Math.log10(weight) - 2.5) * 3.0
+  return Math.max(8, Math.min(17, r))
+}
+
+// Mid-radius (intrinsic coords, viewBox space without the PAD offset) of a ring band.
+export function ringMidRadius(ringIndex: number): number {
+  const inner = BOUNDS[ringIndex] ?? 0
+  const outer = BOUNDS[ringIndex + 1] ?? BOUNDS[BOUNDS.length - 1] ?? 0
+  return ((inner + outer) / 2) * R
+}
+
+export function buildBlips(tools: RadarTool[]): Blip[] {
+  const out: Blip[] = []
+  let n = 0
+  for (const q of RADAR_QUADRANTS) {
+    for (const ring of RADAR_RINGS) {
+      const ri = RADAR_RINGS.indexOf(ring)
+      const group = tools
+        .filter((t) => t.quadrant === q.key && t.ring === ring)
+        .sort((a, b) => magnitude(b.stars || b.downloads) - magnitude(a.stars || a.downloads))
+      const angle = QUAD_ANGLE[q.key]
+      const aStart = angle[0] + A_PAD
+      const aEnd = angle[1] - A_PAD
+      const bandIn = (BOUNDS[ri] ?? 0) * R
+      const bandOut = (BOUNDS[ri + 1] ?? 0) * R
+      group.forEach((t, gi) => {
+        n += 1
+        const frac = group.length === 1 ? 0.5 : gi / (group.length - 1)
+        const ang = ((aStart + frac * (aEnd - aStart)) * Math.PI) / 180
+        // alternate inner/outer within the band so neighbours don't collide
+        const sub = group.length === 1 ? 0.5 : gi % 2 === 0 ? 0.36 : 0.66
+        const rad = bandIn + (bandOut - bandIn) * sub
+        const weight = magnitude(t.stars || t.downloads)
+        out.push({
+          ...t,
+          number: n,
+          weight,
+          r: radiusFor(weight),
+          x: R + rad * Math.cos(ang),
+          y: R + rad * Math.sin(ang),
+        })
+      })
+    }
+  }
+  return out
+}
+
+// ── Transform math ──────────────────────────────────────────────────────────
+//
+// The SVG content is wrapped in a `<g transform="translate(x,y) scale(s)">`.
+// A point P in *content* space maps to screen space as  P * s + (x, y).
+// Anchored zoom keeps the content point under the cursor invariant while the
+// scale changes, which is the single biggest "feels modern" detail.
+
+/**
+ * Compute the new transform after zooming toward an anchor expressed in the
+ * SVG's *intrinsic viewBox* coordinate system (i.e. the same units the blips
+ * use, already offset by PAD). Solving `anchor*newScale + newXY = anchor*oldScale + oldXY`.
+ */
+export function anchoredZoom(
+  t: Transform,
+  nextScaleRaw: number,
+  anchor: { x: number; y: number }
+): Transform {
+  const scale = clampScale(nextScaleRaw)
+  if (scale === t.scale) return t
+  return {
+    scale,
+    x: anchor.x - (anchor.x - t.x) * (scale / t.scale),
+    y: anchor.y - (anchor.y - t.y) * (scale / t.scale),
+  }
+}
+
+/** Center a given content point on screen at a target scale. */
+export function centerOn(
+  point: { x: number; y: number },
+  scale: number,
+  viewportCenter: { x: number; y: number }
+): Transform {
+  const s = clampScale(scale)
+  return {
+    scale: s,
+    x: viewportCenter.x - point.x * s,
+    y: viewportCenter.y - point.y * s,
+  }
+}
+
+// Quadrant centroids in viewBox user-space. Each quadrant sits at ~52% of the
+// outer radius along its diagonal. (Center is (R, R) — no PAD offset.)
+const QUAD_CENTROID_FRAC = 0.52
+export function quadrantCentroid(quadrant: RadarQuadrant): { x: number; y: number } {
+  const [a0, a1] = QUAD_ANGLE[quadrant]
+  const mid = (((a0 + a1) / 2) * Math.PI) / 180
+  const rad = OUTER * QUAD_CENTROID_FRAC
+  return { x: CENTER + rad * Math.cos(mid), y: CENTER + rad * Math.sin(mid) }
+}
+
+/** viewBox user-space coords of a blip (blips already live in this space). */
+export function blipPoint(b: Blip): { x: number; y: number } {
+  return { x: b.x, y: b.y }
+}
+
+export function transformStyle(t: Transform): string {
+  return `translate(${t.x} ${t.y}) scale(${t.scale})`
+}
+
+/** Did the pointer move far enough to count as a drag rather than a click? */
+export const DRAG_THRESHOLD = 5

--- a/apps/web/src/components/radar/useRadarTransform.ts
+++ b/apps/web/src/components/radar/useRadarTransform.ts
@@ -1,0 +1,185 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  IDENTITY,
+  type Transform,
+  VIEW,
+  VIEW_MIN,
+  anchoredZoom,
+  centerOn,
+  clampScale,
+} from './geometry'
+import { useReducedMotion } from './useReducedMotion'
+
+const EASE_MS = 420
+// easeOutCubic — settles quickly, feels responsive without overshoot jitter.
+const easeOutCubic = (t: number) => 1 - (1 - t) ** 3
+
+interface ViewportCenter {
+  x: number
+  y: number
+}
+
+interface UseRadarTransform {
+  transform: Transform
+  /** The SVG element ref — attach to the radar `<svg>`. */
+  svgRef: React.RefObject<SVGSVGElement>
+  /** Convert a client (screen) point to viewBox user-space coords. */
+  toUserSpace: (clientX: number, clientY: number) => { x: number; y: number }
+  /** Center of the visible viewport in viewBox user-space. */
+  viewportCenter: () => ViewportCenter
+  /** Anchored zoom toward a viewBox-user-space point (live gesture — no animation). */
+  zoomAt: (factor: number, anchor: { x: number; y: number }) => void
+  /** Zoom toward the viewport center by a multiplicative factor (button — animated). */
+  zoomBy: (factor: number) => void
+  /** Pan by a screen-pixel delta (live gesture — no animation). */
+  panByPixels: (dxPx: number, dyPx: number) => void
+  /** Animate (or jump) to an arbitrary transform. */
+  animateTo: (target: Transform) => void
+  /** Smoothly center a viewBox-user-space point at a target scale. */
+  focusPoint: (point: { x: number; y: number }, scale: number) => void
+  /** Reset to the identity (full radar) view, eased. */
+  reset: () => void
+  isAnimating: () => boolean
+}
+
+export function useRadarTransform(): UseRadarTransform {
+  const [transform, setTransform] = useState<Transform>(IDENTITY)
+  const transformRef = useRef<Transform>(IDENTITY)
+  const svgRef = useRef<SVGSVGElement>(null)
+  const rafRef = useRef<number | null>(null)
+  const reducedMotion = useReducedMotion()
+  const reducedRef = useRef(reducedMotion)
+  reducedRef.current = reducedMotion
+
+  // Keep the ref in lockstep so gesture handlers read the latest transform.
+  const commit = useCallback((next: Transform) => {
+    transformRef.current = next
+    setTransform(next)
+  }, [])
+
+  const cancelAnim = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+  }, [])
+
+  useEffect(() => () => cancelAnim(), [cancelAnim])
+
+  // px-per-user-unit: the SVG renders VIEW user units across `meet`-fit space.
+  const pxPerUnit = useCallback((): number => {
+    const el = svgRef.current
+    if (!el) return 1
+    const rect = el.getBoundingClientRect()
+    const fit = Math.min(rect.width, rect.height) || 1
+    return fit / VIEW
+  }, [])
+
+  const toUserSpace = useCallback((clientX: number, clientY: number) => {
+    const el = svgRef.current
+    if (!el) return { x: 0, y: 0 }
+    const rect = el.getBoundingClientRect()
+    // The viewBox is square (VIEW×VIEW) with xMidYMid meet — letterboxed.
+    const fit = Math.min(rect.width, rect.height) || 1
+    const offsetX = (rect.width - fit) / 2
+    const offsetY = (rect.height - fit) / 2
+    const localX = clientX - rect.left - offsetX
+    const localY = clientY - rect.top - offsetY
+    return {
+      x: VIEW_MIN + (localX / fit) * VIEW,
+      y: VIEW_MIN + (localY / fit) * VIEW,
+    }
+  }, [])
+
+  const viewportCenter = useCallback((): ViewportCenter => {
+    const el = svgRef.current
+    if (!el) return { x: VIEW_MIN + VIEW / 2, y: VIEW_MIN + VIEW / 2 }
+    const rect = el.getBoundingClientRect()
+    return toUserSpace(rect.left + rect.width / 2, rect.top + rect.height / 2)
+  }, [toUserSpace])
+
+  const animateTo = useCallback(
+    (target: Transform) => {
+      cancelAnim()
+      const clamped: Transform = { ...target, scale: clampScale(target.scale) }
+      if (reducedRef.current) {
+        commit(clamped)
+        return
+      }
+      const from = transformRef.current
+      // Skip the rAF loop for no-op moves.
+      if (from.x === clamped.x && from.y === clamped.y && from.scale === clamped.scale) return
+      const start = performance.now()
+      const tick = (now: number) => {
+        const p = Math.min(1, (now - start) / EASE_MS)
+        const k = easeOutCubic(p)
+        commit({
+          x: from.x + (clamped.x - from.x) * k,
+          y: from.y + (clamped.y - from.y) * k,
+          scale: from.scale + (clamped.scale - from.scale) * k,
+        })
+        if (p < 1) rafRef.current = requestAnimationFrame(tick)
+        else rafRef.current = null
+      }
+      rafRef.current = requestAnimationFrame(tick)
+    },
+    [cancelAnim, commit]
+  )
+
+  const zoomAt = useCallback(
+    (factor: number, anchor: { x: number; y: number }) => {
+      cancelAnim()
+      const cur = transformRef.current
+      commit(anchoredZoom(cur, cur.scale * factor, anchor))
+    },
+    [cancelAnim, commit]
+  )
+
+  const zoomBy = useCallback(
+    (factor: number) => {
+      const cur = transformRef.current
+      const next = anchoredZoom(cur, cur.scale * factor, viewportCenter())
+      animateTo(next)
+    },
+    [animateTo, viewportCenter]
+  )
+
+  const panByPixels = useCallback(
+    (dxPx: number, dyPx: number) => {
+      cancelAnim()
+      const ppu = pxPerUnit()
+      const cur = transformRef.current
+      // Translate the <g> by the same screen delta (transform translate is in user units * 1,
+      // but the whole SVG is scaled by ppu on screen, so divide the pixel delta back out).
+      commit({ ...cur, x: cur.x + dxPx / ppu, y: cur.y + dyPx / ppu })
+    },
+    [cancelAnim, commit, pxPerUnit]
+  )
+
+  const focusPoint = useCallback(
+    (point: { x: number; y: number }, scale: number) => {
+      animateTo(centerOn(point, scale, viewportCenter()))
+    },
+    [animateTo, viewportCenter]
+  )
+
+  const reset = useCallback(() => animateTo(IDENTITY), [animateTo])
+
+  const isAnimating = useCallback(() => rafRef.current !== null, [])
+
+  return {
+    transform,
+    svgRef,
+    toUserSpace,
+    viewportCenter,
+    zoomAt,
+    zoomBy,
+    panByPixels,
+    animateTo,
+    focusPoint,
+    reset,
+    isAnimating,
+  }
+}

--- a/apps/web/src/components/radar/useReducedMotion.ts
+++ b/apps/web/src/components/radar/useReducedMotion.ts
@@ -1,0 +1,22 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * Tracks the `prefers-reduced-motion` media query. Returns `true` when the user
+ * has asked for reduced motion, so callers can jump instantly instead of
+ * animating. SSR-safe: defaults to `false` until mounted.
+ */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false)
+
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const onChange = () => setReduced(mql.matches)
+    onChange()
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [])
+
+  return reduced
+}

--- a/apps/web/src/data/crateRadar.ts
+++ b/apps/web/src/data/crateRadar.ts
@@ -1,0 +1,188 @@
+// Rust & AI Crate Radar — data source for the /radar page.
+//
+// This file is the on-site snapshot of the tools featured across the blog &
+// newsletter. It is meant to be regenerated from AllSource Prime (the
+// `tool` nodes, domain `rust-ai`) as part of the publish flow — see
+// docs/SOCIAL_POSTING_SETUP.md / the rust-ai-weekly-roundup skill. Until the
+// generator is wired, update it here when an issue ships.
+//
+// Rings are the editorial verdict (ThoughtWorks Tech Radar vocabulary):
+//   Adopt  — proven, safe to standardize on
+//   Trial  — worth using on real work, with eyes open
+//   Assess — promising; explore before betting
+//   Hold   — proceed with caution / don't newly depend yet
+
+export type RadarRing = 'Adopt' | 'Trial' | 'Assess' | 'Hold'
+export type RadarQuadrant = 'agentic' | 'inference' | 'data' | 'dev'
+
+export interface RadarTool {
+  name: string
+  url: string
+  category: string
+  quadrant: RadarQuadrant
+  ring: RadarRing
+  maintenance: string
+  latest: string
+  stars?: string
+  downloads?: string
+  adopters?: string
+  mentions: string
+  /** true if featured in more than one issue/article */
+  returning: boolean
+  note?: string
+}
+
+export const RADAR_GENERATED_AT = '2026-06-19'
+
+export const RADAR_QUADRANTS: { key: RadarQuadrant; label: string }[] = [
+  { key: 'agentic', label: 'Agentic & LLM' },
+  { key: 'inference', label: 'Inference & Serving' },
+  { key: 'data', label: 'Data & Search' },
+  { key: 'dev', label: 'Dev Tools & Editors' },
+]
+
+export const RADAR_RINGS: RadarRing[] = ['Adopt', 'Trial', 'Assess', 'Hold']
+
+export const crateRadarTools: RadarTool[] = [
+  // ── Agentic & LLM ──
+  {
+    name: 'goose', url: 'https://github.com/block/goose', category: 'agentic', quadrant: 'agentic',
+    ring: 'Adopt', maintenance: 'very actively maintained (Block-backed, 400+ contributors)',
+    latest: 'v1.29.1 (Apr 2026)', stars: '~35k★', adopters: 'Block (internal use)',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+    note: 'Rust-core agent/CLI; desktop UI is TypeScript',
+  },
+  {
+    name: 'rmcp', url: 'https://github.com/modelcontextprotocol/rust-sdk', category: 'agentic', quadrant: 'agentic',
+    ring: 'Adopt', maintenance: 'actively maintained (official MCP org)', latest: 'v1.7.0 (May 2026)',
+    stars: '~3.4k★', downloads: '~13M', adopters: 'canonical Rust MCP SDK',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+  },
+  {
+    name: 'rig', url: 'https://github.com/0xPlaygrounds/rig', category: 'agentic', quadrant: 'agentic',
+    ring: 'Trial', maintenance: 'actively maintained', latest: 'rig-core 0.38.2 (Jun 2026)',
+    stars: '~7k★', downloads: '~1.2M', adopters: 'Neon, St. Jude, Nethermind, Dria, Coral Protocol',
+    mentions: 'Crate Radar (2026-06-18); Rust & AI Weekly #1 (2026-06-19)', returning: true,
+  },
+  {
+    name: 'genai', url: 'https://github.com/jeremychone/rust-genai', category: 'agentic/client', quadrant: 'agentic',
+    ring: 'Trial', maintenance: 'actively maintained (solo maintainer — bus-factor)', latest: 'v0.6.0 (May 2026)',
+    stars: '~800★', adopters: "AIPack (author's tooling); 25+ providers",
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+  },
+  {
+    name: 'async-openai', url: 'https://github.com/64bit/async-openai', category: 'agentic/client', quadrant: 'agentic',
+    ring: 'Trial', maintenance: 'actively maintained (solo)', latest: 'v0.41.0 (Jun 2026)',
+    stars: '~1.9k★', downloads: '~5.7M', adopters: 'de-facto OpenAI client across ecosystem',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+  },
+  {
+    name: 'swiftide', url: 'https://github.com/bosun-ai/swiftide', category: 'agentic/RAG', quadrant: 'agentic',
+    ring: 'Assess', maintenance: 'maintained, pre-1.0, small team', latest: 'v0.32.1 (Nov 2025)',
+    stars: '~710★', downloads: '~82k', adopters: 'bosun.ai (primary)',
+    mentions: 'Crate Radar (2026-06-18); Rust & AI Weekly #1 (2026-06-19)', returning: true,
+  },
+  {
+    name: 'kalosm', url: 'https://github.com/floneum/floneum', category: 'agentic/local-models', quadrant: 'agentic',
+    ring: 'Hold', maintenance: 'slowing — mid-rewrite (WGPU backend)', latest: 'v0.4.0 (Feb 2025)',
+    stars: '~2.2k★', adopters: 'none named',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false, note: 'experimental',
+  },
+
+  // ── Inference & Serving ──
+  {
+    name: 'candle', url: 'https://github.com/huggingface/candle', category: 'inference', quadrant: 'inference',
+    ring: 'Adopt', maintenance: 'actively maintained (Hugging Face)', latest: 'candle-core 0.10.2 (Apr 2026)',
+    stars: '~20k★', adopters: 'anchors mistral.rs, kalosm; Hugging Face',
+    mentions: 'Crate Radar (2026-06-18); Rust & AI Weekly #1 (2026-06-19)', returning: true,
+  },
+  {
+    name: 'ort', url: 'https://github.com/pykeio/ort', category: 'inference', quadrant: 'inference',
+    ring: 'Adopt', maintenance: 'actively maintained', latest: 'v2.0.0-rc.12 (Mar 2026; pre-1.0 API)',
+    downloads: '~10.8M', adopters: 'Twitter/X, SurrealDB, Bloop, Google Magika, Wasmtime',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+  },
+  {
+    name: 'tract', url: 'https://github.com/sonos/tract', category: 'inference', quadrant: 'inference',
+    ring: 'Adopt', maintenance: 'actively maintained (Sonos)', latest: 'v0.21.15 (Mar 2026)',
+    stars: '~2.9k★', downloads: 'sub-crates ~1M each', adopters: 'Sonos (wake-word + ASR on millions of devices)',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+  },
+  {
+    name: 'mistral.rs', url: 'https://github.com/EricLBuehler/mistral.rs', category: 'inference', quadrant: 'inference',
+    ring: 'Trial', maintenance: 'actively maintained — high velocity, single maintainer (bus-factor)', latest: 'v0.8.2 (2026)',
+    stars: '~6.5k★', adopters: 'none named',
+    mentions: 'Crate Radar (2026-06-18); Rust & AI Weekly #1 (2026-06-19)', returning: true,
+  },
+  {
+    name: 'llama-cpp-2', url: 'https://github.com/utilityai/llama-cpp-rs', category: 'inference', quadrant: 'inference',
+    ring: 'Trial', maintenance: 'actively maintained, tracks upstream llama.cpp (no semver — pin)', latest: '0.1.146 (Apr 2026)',
+    stars: '~580★', downloads: 'llama-cpp-sys-2 ~655k', adopters: 'UtilityAI',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+  },
+  {
+    name: 'burn', url: 'https://github.com/tracel-ai/burn', category: 'inference/training', quadrant: 'inference',
+    ring: 'Assess', maintenance: 'actively maintained (Tracel AI)', latest: 'v0.20.0 (Jan 2026, CubeK)',
+    stars: '~15k★', adopters: 'none named',
+    mentions: 'Crate Radar (2026-06-18); Rust & AI Weekly #1 (2026-06-19)', returning: true,
+  },
+  {
+    name: 'luminal', url: 'https://github.com/luminal-ai/luminal', category: 'inference/training', quadrant: 'inference',
+    ring: 'Assess', maintenance: 'actively developed via main (release tags lag; pre-1.0)', latest: 'active commits mid-2026 (last tag 0.2)',
+    stars: '~2.9k★', adopters: 'YC S25, $5.3M seed; research use at Yale',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false, note: 'one-to-watch / pre-1.0',
+  },
+
+  // ── Data & Search ──
+  {
+    name: 'qdrant', url: 'https://github.com/qdrant/qdrant', category: 'data/vectors', quadrant: 'data',
+    ring: 'Adopt', maintenance: 'actively maintained', latest: 'v1.17.1 (Mar 2026)',
+    stars: '~31k★', adopters: 'Tripadvisor, HubSpot; Qdrant Cloud',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+  },
+  {
+    name: 'lancedb', url: 'https://github.com/lancedb/lancedb', category: 'data/vectors', quadrant: 'data',
+    ring: 'Adopt', maintenance: 'very actively maintained, nearing 1.0', latest: 'v0.33.x beta (Jun 2026)',
+    stars: '~10.5k★', adopters: 'Netflix, CodeRabbit; Cloud/Enterprise',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+    note: 'Rust-core (Lance format) with Python/JS/Java bindings',
+  },
+  {
+    name: 'tantivy', url: 'https://github.com/quickwit-oss/tantivy', category: 'data/search', quadrant: 'data',
+    ring: 'Adopt', maintenance: 'actively maintained (Quickwit)', latest: 'v0.26.x (2026)',
+    downloads: 'sub-crates ~10M each', adopters: 'Quickwit, ParadeDB',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+  },
+  {
+    name: 'fastembed-rs', url: 'https://github.com/Anush008/fastembed-rs', category: 'data/embeddings', quadrant: 'data',
+    ring: 'Trial', maintenance: 'actively maintained (frequent releases)', latest: 'v5.17.2 (Jun 2026)',
+    stars: '~900★', downloads: '~1.5M', adopters: 'integrates with rig',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+  },
+  {
+    name: 'Stoolap', url: 'https://github.com/stoolap/stoolap', category: 'data/vectors', quadrant: 'data',
+    ring: 'Assess', maintenance: 'actively maintained but early/pre-1.0', latest: 'v0.3.1 (2026)',
+    stars: '~540★', adopters: 'none yet',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false, note: 'one-to-watch',
+  },
+
+  // ── Dev Tools & Editors ──
+  {
+    name: 'Zed', url: 'https://github.com/zed-industries/zed', category: 'dev-tools/editor', quadrant: 'dev',
+    ring: 'Adopt', maintenance: 'actively maintained (Zed Industries)', latest: 'stable Jun 2026; v1.0 in 2026',
+    stars: '~83k★', adopters: 'VC-backed; native agentic editing',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+  },
+  {
+    name: 'aichat', url: 'https://github.com/sigoden/aichat', category: 'dev-tools/cli', quadrant: 'dev',
+    ring: 'Trial', maintenance: 'actively maintained', latest: 'v0.28.0 (Feb 2026)',
+    stars: '~10k★', adopters: '20+ LLM providers',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false,
+  },
+  {
+    name: 'Tabby', url: 'https://github.com/TabbyML/tabby', category: 'dev-tools/coding-assistant', quadrant: 'dev',
+    ring: 'Hold', maintenance: 'maintained, but release cadence slowed', latest: 'v0.30 (Jul 2025) — ~11mo gap; commits continue',
+    stars: '~24k★', adopters: 'self-hosted Copilot alternative',
+    mentions: 'Rust & AI Weekly #1 (2026-06-19)', returning: false, note: 'watch-cadence',
+  },
+]

--- a/apps/web/tests/e2e/radar.spec.ts
+++ b/apps/web/tests/e2e/radar.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test'
+
+// Smoke tests for the redesigned full-bleed Crate Radar hero. These gate the
+// things the project cares about: no console errors / hydration issues / missing
+// "use client" directives, plus that the interactive surface and its overlays
+// render and remain keyboard/screen-reader reachable.
+
+test.describe('Crate Radar (/radar)', () => {
+  test('renders full-bleed without console or hydration errors', async ({ page }) => {
+    const errors: string[] = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(msg.text())
+    })
+    page.on('pageerror', (error) => errors.push(error.message))
+
+    await page.goto('/radar')
+    await page.waitForLoadState('networkidle')
+
+    // The interactive surface is present and labelled as an application.
+    const surface = page.getByRole('application', { name: /crate radar/i })
+    await expect(surface).toBeVisible()
+
+    // Full-bleed: the surface should be roughly the viewport width (no big gutters).
+    const viewport = page.viewportSize()
+    if (viewport) {
+      const box = await surface.boundingBox()
+      expect(box).not.toBeNull()
+      if (box) expect(box.width).toBeGreaterThan(viewport.width * 0.9)
+    }
+
+    // Live count is announced.
+    await expect(page.getByText(/Showing \d+ of \d+ tools/)).toBeVisible()
+
+    const critical = errors.filter(
+      (e) =>
+        !e.includes('favicon') &&
+        !e.includes('ERR_CONNECTION_REFUSED') &&
+        !e.toLowerCase().includes('ollama')
+    )
+    expect(critical, `Console/page errors:\n${critical.join('\n')}`).toHaveLength(0)
+  })
+
+  test('blips keep descriptive aria-labels and are focusable', async ({ page }) => {
+    await page.goto('/radar')
+    await page.waitForLoadState('networkidle')
+
+    // At least one blip exposes the "name, ring, quadrant" aria-label contract.
+    const goose = page.getByRole('button', { name: /goose, Adopt, Agentic/i })
+    await expect(goose).toBeVisible()
+  })
+
+  test('ring filter toggles the live count', async ({ page }) => {
+    await page.goto('/radar')
+    await page.waitForLoadState('networkidle')
+
+    const count = page.getByText(/Showing \d+ of \d+ tools/)
+    const before = await count.textContent()
+
+    // Toggle the "Hold" ring off.
+    await page.getByRole('button', { name: /^Hold/ }).click()
+    await expect(count).not.toHaveText(before ?? '')
+  })
+
+  test('zoom + reset controls are keyboard reachable', async ({ page }) => {
+    await page.goto('/radar')
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByRole('button', { name: 'Zoom in' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Zoom out' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Reset view' })).toBeVisible()
+  })
+
+  test('⌘K command palette opens and lists tools', async ({ page }) => {
+    await page.goto('/radar')
+    await page.waitForLoadState('networkidle')
+
+    await page.keyboard.press('ControlOrMeta+k')
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    const input = dialog.getByPlaceholder(/search tools/i)
+    await expect(input).toBeVisible()
+    await input.fill('qdrant')
+    await expect(dialog.getByText(/qdrant/i).first()).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(dialog).toBeHidden()
+  })
+})


### PR DESCRIPTION
## What

Redesign `/radar` (Rust & AI Crate Radar) from a small centered card surrounded by empty page gutters into an immersive **full-bleed, canvas-like hero** that owns the viewport.

The 347-line `CrateRadar` monolith is decomposed into focused modules under `apps/web/src/components/radar/` plus a pure `geometry.ts` (all blip-placement math preserved verbatim). `CrateRadar.tsx` becomes a thin re-export of `RadarHero`.

## Highlights

- **Hybrid render** — ambient CSS backdrop (glow / grid / vignette) behind the SVG; interactive blips stay real focusable DOM nodes with intact `aria-label`s.
- **One transform, two layers** — a single `{x,y,scale}` state drives pan/zoom, quadrant focus, and center-on-blip. Live gestures set state directly; programmatic moves `requestAnimationFrame`-ease and honor `prefers-reduced-motion`. The backdrop deliberately does not pan, so the layers can't desync.
- **Pan & zoom** — pointer-drag pan, anchored wheel/pinch zoom (cursor stays invariant), `+`/`-`/`0` keys, visible zoom/reset controls. A 5px drag threshold discriminates drag from a blip click.
- **Click a quadrant to focus** — eased zoom into the sector, dims the other three; Esc / background-click returns.
- **Animated filter transitions** — blips fade/scale on Ring/Area toggle instead of snapping; reduced-motion aware.
- **⌘K command palette** — shadcn `Command` (cmdk), grouped by quadrant, fuzzy search; selecting a tool centers its blip and opens its detail. Always-visible trigger for touch/discoverability.
- **Glass overlays** — filters + detail-on-demand float over the canvas; mobile uses a bottom sheet + drawer.

## Constraints honored

- **No new dependencies** (reuses existing `cmdk` / shadcn `Command` + `Sheet`, `lucide-react`). `/radar` first-load JS ~145 kB.
- **`data/crateRadar.ts` schema untouched** (slated for AllSource Prime regeneration).
- Zero accessibility regressions: focusable aria-labeled blips, greyscale-readable verdicts (band + shape, not color alone), live "Showing X of Y" count, keyboard-operable controls.

## Verification

- `task type-check`, `task lint`, `task build` — **clean for the web app** (`bun run type-check` exit 0; all radar files lint clean; build compiles, `/radar` prerenders static).
- New `apps/web/tests/e2e/radar.spec.ts` — **5 Chromium E2E pass**: full-bleed fill, no console/hydration errors, blip aria-labels, ring-filter toggles count, zoom/reset reachable, ⌘K opens/filters/closes.

> Note: repo-wide `task type-check` / `task lint` still report **pre-existing, unrelated** failures (`@decebal/services-admin` `getSupabaseAdmin`; `@decebal/ui` `toaster.tsx` import order) that predate this branch and are untouched here.

## Follow-ups

- Visual tuning best eyeballed live: backdrop glow intensity, quadrant-focus zoom (1.7×), blip-focus zoom (2.1×).
- Optional: harden focus restoration after ⌘K-select via Radix `onCloseAutoFocus`.

---

## Update — radar promo banner on blog posts (commit `18d9b68`)

Adds a compact **Rust & AI Crate Radar** CTA to blog entries, linking to the new `/radar` page (hence bundled in this PR — it depends on the page existing).

- New `RadarBanner` component, two variants: a **slim strip** under the post tags + a **compact card** above the existing *Let's Connect* CTA. A smaller-footprint sibling of `BlogCTA`, same brand-teal visual family.
- `shouldShowRadarBanner()` gates by tag intersection (`rust`, `crates`, `crate-radar`, `ai`, `llm`, `agents`, `inference`) so personal/off-topic posts stay clean — **~15 of 52 posts** qualify.
- Live tool count + ring-color dots tie it to the radar; **server-rendered** (no client JS).
- Verified: web `type-check` clean, `RadarBanner` lints clean, `build` green (199 static pages, `/blog/[slug]` compiles).

> Heads-up: the broad `ai` tag also surfaces the banner on a few tangential posts (the *ML-in-review* trio, the *blackjack-interview* post). Easy to tighten to `rust`/`crates`/`crate-radar` only if preferred.
