### PR TITLE
fix: add opt-out flag to disable PostHog locally

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -31,6 +31,8 @@ NEXT_PUBLIC_SOLANA_NETWORK=devnet  # Use 'mainnet-beta' for production
 # Analytics - PostHog (Optional)
 NEXT_PUBLIC_POSTHOG_KEY=your_posthog_project_key
 NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+# Set to "true" to disable PostHog (client + server). Useful for local dev.
+NEXT_PUBLIC_POSTHOG_DISABLED=false
 
 # Bot Protection - Cloudflare Turnstile (Optional, recommended for production)
 # Get your keys at https://dash.cloudflare.com/

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -12,7 +12,7 @@ const groq = createGroq({
 
 // Initialize PostHog for server-side tracking
 let posthog: PostHog | null = null
-if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+if (process.env.NEXT_PUBLIC_POSTHOG_KEY && process.env.NEXT_PUBLIC_POSTHOG_DISABLED !== 'true') {
   posthog = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
   })

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -27,7 +27,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
   // Initialize PostHog with cookieless tracking for privacy
   // Note: Ensure "Cookieless server hash mode" is enabled in PostHog Project Settings > Web analytics
   useEffect(() => {
-    if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+    if (
+      typeof window !== 'undefined' &&
+      process.env.NEXT_PUBLIC_POSTHOG_KEY &&
+      process.env.NEXT_PUBLIC_POSTHOG_DISABLED !== 'true'
+    ) {
       try {
         posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
           api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',


### PR DESCRIPTION
## Problem

PostHog initialization was gated **only** on `NEXT_PUBLIC_POSTHOG_KEY`. Any local environment with the key present (e.g. `.env.local` pulled from prod) fired analytics, autocapture, and **session recording** straight from `localhost` — polluting product data with dev traffic.

## Change

Add an explicit opt-out flag, `NEXT_PUBLIC_POSTHOG_DISABLED`, checked alongside the key at both init sites:

- `apps/web/src/app/providers.tsx` — client init (cookieless tracking + session recording).
- `apps/web/src/app/api/chat/route.ts` — server-side `posthog-node` init.

Gate is now `NEXT_PUBLIC_POSTHOG_KEY && NEXT_PUBLIC_POSTHOG_DISABLED !== 'true'`.

`.env.example` documents the flag (defaults to `false`). To silence analytics in dev, set `NEXT_PUBLIC_POSTHOG_DISABLED=true` in `.env.local`.

## Notes

- **Production is unaffected** — the flag is absent/`false` there, so behavior is unchanged.
- Default-on (opt-out) was chosen over default-off so analytics keep working unless someone deliberately disables them.
- ⚠️ Disabling PostHog locally also disables **feature flags** (e.g. newsletter flags via `useFeatureFlag`). Flip the flag back to `false` if you need to exercise flags in dev.
- `NEXT_PUBLIC_*` vars are read at process start — restart the dev server after changing the flag.
- Legacy `initAnalytics` (`lib/analytics.ts`, `packages/analytics`) was left untouched — it has no caller (dead path).